### PR TITLE
avoid nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --workspace
 
@@ -35,7 +35,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace
 
@@ -48,6 +48,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -43,7 +43,7 @@ jobs:
           - { os: macos-latest }
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/low-priority-targets.yml
+++ b/.github/workflows/low-priority-targets.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@stable
       with:
         targets: wasm32-wasip1
     - name: check
@@ -39,5 +39,4 @@ jobs:
       shell: 'C:\msys64\usr\bin\bash.exe --login -eo pipefail {0}'
       env:
         CHERE_INVOKING: 1
-        RUSTC_BOOTSTRAP: 1
       run: cargo check --target x86_64-pc-cygwin


### PR DESCRIPTION
Closes https://github.com/uutils/awk/issues/4 .
Needs 1.95+ which is not preinstalled on ubuntu-latest yet.