### PR TITLE
interpreter: implement missing opcodes and Value traits

### DIFF
--- a/interpreter/src/ir.rs
+++ b/interpreter/src/ir.rs
@@ -42,7 +42,6 @@ pub enum OpCode {
     Negation,
     ToInt,
     Negative,
-    Concat,
 
     // Binary operations
     Eq,
@@ -61,6 +60,7 @@ pub enum OpCode {
     Divide,
     Raise,
     Modulo,
+    Concat,
 
     // Intrinsic operations
     LoadUser,

--- a/interpreter/src/types.rs
+++ b/interpreter/src/types.rs
@@ -4,7 +4,7 @@ use std::{
     hash::Hash,
     io::Write,
     mem::discriminant,
-    ops::{Add, Div, Mul, Sub},
+    ops::{Add, Div, Mul, Neg, Not, Rem, Sub},
 };
 
 use ahash::RandomState;
@@ -65,6 +65,14 @@ impl Value<'_> {
         }
     }
 
+    pub fn pow(&self, rhs: &Self) -> Self {
+        Value::Float(self.to_num().powf(rhs.to_num()))
+    }
+
+    pub fn to_int(&self) -> Self {
+        Value::Float(self.to_num().trunc())
+    }
+
     pub fn write_string(&self, f: &mut Vec<u8>) {
         match self {
             Self::String(s) | Self::Regex(s) => f.extend_from_slice(s),
@@ -119,7 +127,44 @@ impl<'a> Div for &'_ Value<'a> {
     }
 }
 
+impl<'a> Rem for &'_ Value<'a> {
+    type Output = Value<'a>;
+
+    fn rem(self, rhs: Self) -> Self::Output {
+        Value::Float(self.to_num() % rhs.to_num())
+    }
+}
+
+impl<'a> Neg for &'_ Value<'a> {
+    type Output = Value<'a>;
+
+    fn neg(self) -> Self::Output {
+        Value::Float(-self.to_num())
+    }
+}
+
+impl<'a> Not for &'_ Value<'a> {
+    type Output = Value<'a>;
+
+    fn not(self) -> Self::Output {
+        Value::Bool(!self.to_bool())
+    }
+}
+
 impl Eq for Value<'_> {}
+impl PartialOrd for Value<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match (self, other) {
+            (Value::Float(a), Value::Float(b)) => a.partial_cmp(b),
+            (Value::Bool(a), Value::Bool(b)) => a.partial_cmp(b),
+            (Value::String(a), Value::String(b)) => a.partial_cmp(b),
+            //TODO: handle mixed type comparisons following awk's coercion rules
+            // (e.g. numeric strings should compare numerically, Unassigned is "" or 0 depending on
+            // context)
+            _ => None,
+        }
+    }
+}
 impl Hash for Value<'_> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         discriminant(self).hash(state);

--- a/interpreter/src/vm.rs
+++ b/interpreter/src/vm.rs
@@ -108,7 +108,16 @@ impl Interpreter<'_> {
     pub fn run(&mut self) {
         while let Some(instr) = self.bc.code.get(self.program_counter) {
             match instr {
-                // ix if let Some(&(dest, src)) = ix.get_unary() => {}
+                ix if let Some(&(dest, src)) = ix.get_unary() => {
+                    let src = self.registers.get(src);
+                    let val = match ix.opcode {
+                        OpCode::Negative => -src,
+                        OpCode::Negation => !src,
+                        OpCode::ToInt => src.to_int(),
+                        _ => todo!(),
+                    };
+                    self.registers.write(dest, val);
+                }
                 ix if let Some(&(dest, lhs, rhs)) = ix.get_binary() => {
                     let val = {
                         let lhs = self.registers.get(lhs);
@@ -118,6 +127,8 @@ impl Interpreter<'_> {
                             OpCode::Subtract => lhs - rhs,
                             OpCode::Multiply => lhs * rhs,
                             OpCode::Divide => lhs / rhs,
+                            OpCode::Raise => lhs.pow(rhs),
+                            OpCode::Modulo => lhs % rhs,
                             OpCode::Concat => {
                                 let mut buf = StdVec::with_capacity(
                                     lhs.string_size_hint() + rhs.string_size_hint(),
@@ -126,6 +137,14 @@ impl Interpreter<'_> {
                                 rhs.write_string(&mut buf);
                                 Value::String(buf.into())
                             }
+                            OpCode::Eq => Value::Bool(lhs == rhs),
+                            OpCode::NEq => Value::Bool(lhs != rhs),
+                            OpCode::Gt => Value::Bool(lhs > rhs),
+                            OpCode::GtE => Value::Bool(lhs >= rhs),
+                            OpCode::Lt => Value::Bool(lhs < rhs),
+                            OpCode::LtE => Value::Bool(lhs <= rhs),
+                            OpCode::And => Value::Bool(lhs.to_bool() && rhs.to_bool()),
+                            OpCode::Or => Value::Bool(lhs.to_bool() || rhs.to_bool()),
                             _ => todo!(),
                         }
                     };


### PR DESCRIPTION
The interpreter was missing handlers for most opcodes, leaving them as `todo!()`
This PR fills in some of the remaining unary and binary opcode implementations in the VM, along with the supporting traits and methods on `Value` needed to make them work.

`Concat` is moved from the unary to the binary section of `OpCode` since it operates on two values.

`PartialOrd` is implemented for `Value` with mixed type coercion left as a TODO, awk's coercion rules are nuanced enough that some input would be appreciated before proceeding.