### PR TITLE
parser: recognize exponentiation operators

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -365,6 +365,7 @@ impl<'a> BinaryOperator {
             Token::Minus => Ok(Self::Subtract),
             Token::Star => Ok(Self::Multiply),
             Token::Slash => Ok(Self::Divide),
+            Token::Circumflex => Ok(Self::Raise),
             Token::BooleanAnd => Ok(Self::And),
             Token::BooleanOr => Ok(Self::Or),
             Token::Percent => Ok(Self::Modulo),
@@ -521,7 +522,7 @@ impl BindingPower for BinaryOperator {
             Self::Multiply => binding_powers::BP_MULTI,
             Self::Divide => binding_powers::BP_MULTI,
             Self::Raise => binding_powers::BP_RAISE,
-            Self::Modulo => binding_powers::BP_RAISE,
+            Self::Modulo => binding_powers::BP_MULTI,
         }
     }
 }

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -195,6 +195,40 @@ fn test_parser_non_assoc() {
 }
 
 #[test]
+fn test_parser_exponentiation() {
+    let source = "
+        { 2 ^ 1 }
+        { 2 ** 1 }
+        { 2 ^ 3 ^ 4 }
+        { 2 * 3 ^ 4 }
+        { 2 ^ 3 * 4 }
+    ";
+    test_parser!(source => {
+        rules: [
+            (None, Some("(body (Raise 2 1))")),
+            (None, Some("(body (Raise 2 1))")),
+            (None, Some("(body (Raise 2 (Raise 3 4)))")),
+            (None, Some("(body (Multiply 2 (Raise 3 4)))")),
+            (None, Some("(body (Multiply (Raise 2 3) 4))")),
+        ],
+    });
+}
+
+#[test]
+fn test_parser_multiplicative_precedence() {
+    let source = "
+        { 2 * 3 % 4 }
+        { 2 % 3 * 4 }
+    ";
+    test_parser!(source => {
+        rules: [
+            (None, Some("(body (Modulo (Multiply 2 3) 4))")),
+            (None, Some("(body (Multiply (Modulo 2 3) 4))")),
+        ],
+    });
+}
+
+#[test]
 fn test_parser_relaxed_assignments() {
     let source = "
         { 1 + 0 && x = 1 }


### PR DESCRIPTION
## Summary

- Map the lexer `Circumflex` token to `BinaryOperator::Raise`, so both `^` and `**` parse as exponentiation.
- Keep `%` at multiplicative precedence instead of exponentiation precedence.
- Add parser regression coverage for exponentiation precedence, right associativity, and mixed `*`/`%` expressions.

Fixes #35.

## Checks

All checks were run with Rust/Cargo stable 1.96.0.

- `cargo test -p parser test_parser_exponentiation`
- `cargo test -p parser test_parser_multiplicative_precedence`
- `cargo test -p parser`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo check --target wasm32-wasip1`
- `git diff --check`