### PR TITLE
interpreter: widen instructions, immediates

### DIFF
--- a/interpreter/src/ir.rs
+++ b/interpreter/src/ir.rs
@@ -12,205 +12,198 @@
 
 pub mod lower;
 
-use std::fmt::{Debug, Display};
+use std::fmt::{self, Debug, Display, Formatter};
 
 pub use lower::test_interpreter;
 use parser::{Command, Redirection};
 
+pub type RegWidth = u8;
+pub type IxWidth = u32;
+
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
-pub struct NonLocal(pub u16);
+pub struct NonLocal(pub IxWidth);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
-pub struct Reg(pub u8);
+pub struct Reg(pub RegWidth);
 
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
-pub struct Label(pub u16);
+pub struct Label(pub IxWidth);
 
-#[derive(Clone, Copy, Debug)]
-#[repr(transparent)]
-pub struct ArgCount(u16);
-
-#[repr(u8, C, align(8))]
-#[derive(Clone, Copy, Debug)]
+#[repr(u8, align(16))]
+#[derive(Clone, Copy)]
 pub enum Instruction {
     // Unary operations
-    Record(UnaryArg),
-    Negation(UnaryArg),
-    ToInt(UnaryArg),
-    Negative(UnaryArg),
-    Copy(UnaryArg),
+    Record { dest: Reg, arg: Arg, ty: ArgTy },
+    Negation { dest: Reg, arg: Arg, ty: ArgTy },
+    ToInt { dest: Reg, arg: Arg, ty: ArgTy },
+    Negative { dest: Reg, arg: Arg, ty: ArgTy },
+    Copy { dest: Reg, arg: Arg, ty: ArgTy },
 
     // Binary operations
-    Eq(BinaryArg),
-    NEq(BinaryArg),
-    Gt(BinaryArg),
-    Lt(BinaryArg),
-    LtE(BinaryArg),
-    GtE(BinaryArg),
-    And(BinaryArg),
-    Or(BinaryArg),
-    Matches(BinaryArg),
-    MatchesNot(BinaryArg),
-    Add(BinaryArg),
-    Subtract(BinaryArg),
-    Multiply(BinaryArg),
-    Divide(BinaryArg),
-    Raise(BinaryArg),
-    Modulo(BinaryArg),
-    Concat(BinaryArg),
+    Eq { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    NEq { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Gt { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Lt { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    LtE { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    GtE { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    And { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Or { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Matches { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    MatchesNot { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Add { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Subtract { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Multiply { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Divide { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Raise { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Modulo { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
+    Concat { dest: Reg, lhs: Arg, rhs: Arg, tyr: ArgTy, tyl: ArgTy },
 
     // Intrinsic operations
-    LoadUserScalar(MemArg),
-    LoadUserArray(MemArgRange),
-    LoadUserMDimArray(MemArgRange),
-    LoadBuiltinScalar(MemArg),
-    LoadBuiltinArray(MemArgRange),
-    LoadConst(MemArg),
-    StoreUserScalar(MemArgImm),
-    StoreBuiltinScalar(MemArgImm),
-    StoreUserArray(MemArgRange),
-    StoreUserMDimArray(MemArgRange),
-    StoreBuiltinArray(MemArgRange),
-    StoreRecord(BinaryArg),
-    IntrinsicCall(CallArgs),
-    OutputCall(OutputCallArgs),
-    UserCall(CallArgs),
-    IndirectCall(CallArgs),
-    Jump(JumpArg),
-    Return(RetArg),
-    Branch(BranchArg),
+    StoreS { dest: Reg, ty_place: ArgTy, var: NonLocal, arg: Arg, ty: ArgTy },
+    StoreR { dest: Reg, src: Arg, arg: Arg, ty: ArgTy, tys: ArgTy },
+    StoreA { dest: Reg, ty_place: ArgTy, start: Reg, end: Reg, var: NonLocal, arg: Reg },
+    LoadA { dest: Reg, ty_place: ArgTy, start: Reg, end: Reg, var: NonLocal },
+    IntrinsicCall { dest: Reg, start: Reg, end: Reg, name: NonLocal },
+    OutputCall { start: Reg, end: Reg, cmd: Command, redir: Option<Redirection> },
+    UserCall { dest: Reg, start: Reg, end: Reg, name: NonLocal },
+    IndirectCall { dest: Reg, start: Reg, end: Reg, name: Arg, ty: ArgTy },
+    Jump { to: Label },
+    Return { arg: Arg, ty: ArgTy },
+    Branch { then_label: Label, else_label: Label, condition: Reg },
 }
 
-const _: () = const { assert!(size_of::<Instruction>() <= 8) };
+const _: () = const { assert!(size_of::<Instruction>() <= size_of::<u128>()) };
 
-pub type UnaryArg = (Reg, MaybeImm);
-pub type BinaryArg = (Reg, MaybeImm, MaybeImm);
-pub type MemArgImm = (Reg, MaybeImm, NonLocal);
-pub type MemArgRange = (Reg, Reg, Reg, NonLocal);
-pub type MemArg = (Reg, NonLocal);
-pub type JumpArg = Label;
-pub type RetArg = MaybeImm;
-pub type BranchArg = (MaybeImm, Label, Label);
-pub type CallArgs = (Reg, Reg, Reg, NonLocal);
-pub type OutputCallArgs = (Reg, Reg, Command, Option<Redirection>);
-pub type IndCallArgs = (Reg, Reg, Reg, Reg);
+#[derive(Clone, Copy)]
+pub union Arg {
+    pub reg: Reg,
+    pub imm: i32,
+    pub sym: NonLocal,
+}
 
-#[repr(u8)]
+#[derive(Clone, Copy)]
+struct Imm(u32);
+
 #[derive(Clone, Copy, Debug)]
-pub enum MaybeImm {
-    Reg(Reg),
-    Rec(i8),
-    Imm(i8),
-    ImmCnt(u8),
-    ImmUserVar(u8),
-    ImmBuiltinVar(u8),
+pub enum ArgTy {
+    Reg,
+    Imm,
+    ImmF,
+    Rec,
+    Cnt,
+    UsVal,
+    UaVal,
+    UmVal,
+    IsVal,
+    IaVal,
+    ImVal,
 }
 
 impl Instruction {
     fn set_label(&mut self, label: Label) {
         match self {
-            Self::Jump(lx) | Self::Branch((_, _, lx)) => *lx = label,
+            Self::Jump { to } | Self::Branch { else_label: to, then_label: _, condition: _ } => {
+                *to = label;
+            }
             _ => debug_assert!(false, "Incorrect label set!"),
         }
     }
 
     fn push_end_label(&mut self) {
-        if let Self::Branch((_, _, label)) = self {
-            label.0 += 1;
+        if let Self::Branch { else_label, then_label: _, condition: _ } = self {
+            else_label.0 += 1;
         } else {
             debug_assert!(false, "Incorrect label set!");
         }
     }
 
-    fn br(cond: MaybeImm, then: Label) -> Self {
-        Self::Branch((cond, then, Label(0)))
+    fn br(condition: Reg, then_label: Label) -> Self {
+        Self::Branch { then_label, else_label: Label(0), condition }
     }
 }
 
 impl Display for Instruction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let op = self.display_name();
+        let fmt_arg = |f: &mut Formatter, arg: &Arg, ty: &ArgTy, sep| match ty {
+            ArgTy::Reg => write!(f, "{sep}{}", unsafe { arg.reg }),
+            ArgTy::Imm => write!(f, "{sep}{ty}({})", unsafe { arg.imm }),
+            _ => write!(f, "{sep}{ty}({})", unsafe { arg.sym }),
+        };
         match self {
-            Self::Record((dest, data))
-            | Self::Negation((dest, data))
-            | Self::ToInt((dest, data))
-            | Self::Negative((dest, data))
-            | Self::Copy((dest, data)) => {
-                write!(f, "{dest} <- {op} {data}")
+            Self::Record { dest, arg, ty }
+            | Self::Negation { dest, arg, ty }
+            | Self::ToInt { dest, arg, ty }
+            | Self::Negative { dest, arg, ty }
+            | Self::Copy { dest, arg, ty } => {
+                write!(f, "{dest} <- {op}")?;
+                fmt_arg(f, arg, ty, " ")
             }
-            Self::Eq((dest, lhs, rhs))
-            | Self::NEq((dest, lhs, rhs))
-            | Self::Gt((dest, lhs, rhs))
-            | Self::Lt((dest, lhs, rhs))
-            | Self::LtE((dest, lhs, rhs))
-            | Self::GtE((dest, lhs, rhs))
-            | Self::And((dest, lhs, rhs))
-            | Self::Or((dest, lhs, rhs))
-            | Self::Matches((dest, lhs, rhs))
-            | Self::MatchesNot((dest, lhs, rhs))
-            | Self::Add((dest, lhs, rhs))
-            | Self::Subtract((dest, lhs, rhs))
-            | Self::Multiply((dest, lhs, rhs))
-            | Self::Divide((dest, lhs, rhs))
-            | Self::Raise((dest, lhs, rhs))
-            | Self::Concat((dest, lhs, rhs))
-            | Self::Modulo((dest, lhs, rhs)) => {
-                write!(f, "{dest} <- {op} {lhs}, {rhs}")
+            Self::Eq { dest, lhs, rhs, tyl, tyr }
+            | Self::NEq { dest, lhs, rhs, tyl, tyr }
+            | Self::Gt { dest, lhs, rhs, tyl, tyr }
+            | Self::Lt { dest, lhs, rhs, tyl, tyr }
+            | Self::LtE { dest, lhs, rhs, tyl, tyr }
+            | Self::GtE { dest, lhs, rhs, tyl, tyr }
+            | Self::And { dest, lhs, rhs, tyl, tyr }
+            | Self::Or { dest, lhs, rhs, tyl, tyr }
+            | Self::Matches { dest, lhs, rhs, tyl, tyr }
+            | Self::MatchesNot { dest, lhs, rhs, tyl, tyr }
+            | Self::Add { dest, lhs, rhs, tyl, tyr }
+            | Self::Subtract { dest, lhs, rhs, tyl, tyr }
+            | Self::Multiply { dest, lhs, rhs, tyl, tyr }
+            | Self::Divide { dest, lhs, rhs, tyl, tyr }
+            | Self::Raise { dest, lhs, rhs, tyl, tyr }
+            | Self::Concat { dest, lhs, rhs, tyl, tyr }
+            | Self::Modulo { dest, lhs, rhs, tyl, tyr } => {
+                write!(f, "{dest} <- {op}")?;
+                fmt_arg(f, lhs, tyl, " ")?;
+                fmt_arg(f, rhs, tyr, ", ")
             }
-            Self::LoadUserScalar((dest, src)) => {
-                write!(f, "{dest} <- {op} user[{src}]")
+            Self::StoreS { dest, ty_place, var, arg, ty } => {
+                write!(f, "{dest} <- {op} {ty_place}({var})")?;
+                fmt_arg(f, arg, ty, ", ")
             }
-            Self::StoreUserScalar((dest, imm, src)) => {
-                write!(f, "{dest} <- {op} user[{src}], {imm}")
+            Self::StoreR { dest, src, arg, ty, tys } => {
+                write!(f, "{dest} <- {op} $(")?;
+                fmt_arg(f, src, tys, "")?;
+                fmt_arg(f, arg, ty, "), ")
             }
-            Self::LoadUserArray((dest, start, end, src))
-            | Self::StoreUserArray((dest, start, end, src)) => {
-                write!(f, "{dest} <- {op} user[{start}..{end}], {src}")
+            Self::StoreA { dest, ty_place, start, end, var, arg } => {
+                write!(f, "{dest} <- {op} {ty_place}({var}), {start}..{end}, {arg}")
             }
-            Self::LoadUserMDimArray((dest, start, end, src))
-            | Self::StoreUserMDimArray((dest, start, end, src)) => {
-                write!(f, "{dest} <- {op} user[{src}], {start}..{end}")
+            Self::LoadA { dest, ty_place, start, end, var } => {
+                write!(f, "{dest} <- {op} {ty_place}({var}), {start}..{end})")
             }
-            Self::LoadConst((dest, src)) => {
-                write!(f, "{dest} <- {op} mem[{src}]")
+            Self::Branch { condition, then_label, else_label } => {
+                write!(f, "{op} {condition}, {then_label}, {else_label}")
             }
-            Self::StoreBuiltinScalar((dest, imm, src)) => {
-                write!(f, "{dest} <- {op} intrinsic[{src}], {imm}")
+            Self::Jump { to } => {
+                write!(f, "{op} {to}")
             }
-            Self::LoadBuiltinScalar((dest, src)) => {
-                write!(f, "{dest} <- {op} intrinsic[{src}]")
+            Self::Return { arg, ty } => {
+                write!(f, "{op}")?;
+                fmt_arg(f, arg, ty, " ")
             }
-            Self::StoreRecord((dest, src, imm)) => {
-                write!(f, "{dest} <- {op} {src}, {imm}")
+            Self::IntrinsicCall { dest, start, end, name } => {
+                write!(f, "{dest} <- {op} {name}, {start}..{end}")
             }
-            Self::LoadBuiltinArray((dest, start, end, src))
-            | Self::StoreBuiltinArray((dest, start, end, src)) => {
-                write!(f, "{dest} <- {op} intrinsic[{src}], {start}..{end}")
+            Self::IndirectCall { dest, start, end, name, ty } => {
+                write!(f, "{dest} <- {op}")?;
+                fmt_arg(f, name, ty, " ")?;
+                write!(f, ", {start}..{end}")
             }
-            Self::Branch((cond, label_then, label_else)) => {
-                write!(f, "{op} {cond}, {label_then}, {label_else}")
+            Self::OutputCall { start, end, cmd, redir: Some(redir) } => {
+                write!(f, "{cmd}{redir:?} {start}..{end}")
             }
-            Self::Jump(label) => {
-                write!(f, "{op} {label}")
+            Self::OutputCall { start, end, cmd, redir: None } => {
+                write!(f, "{cmd} {start}..{end}")
             }
-            Self::Return(src) => {
-                write!(f, "{op} {src}")
-            }
-            Self::IntrinsicCall((dest, start, end, fun))
-            | Self::IndirectCall((dest, start, end, fun)) => {
-                write!(f, "{dest} <- {op} {fun}, {start}..{end}")
-            }
-            Self::OutputCall((start, end, call, Some(redir))) => {
-                write!(f, "{call}{redir:?} {start}..{end}")
-            }
-            Self::OutputCall((start, end, call, None)) => {
-                write!(f, "{call} {start}..{end}")
-            }
-            Self::UserCall((dest, start, end, fun)) => {
-                write!(f, "{dest} <- {op} {fun}, {start}..{end}")
+            Self::UserCall { dest, start, end, name } => {
+                write!(f, "{dest} <- {op} {name}, {start}..{end}")
             }
         }
     }
@@ -219,84 +212,82 @@ impl Display for Instruction {
 impl Instruction {
     fn display_name(self) -> &'static str {
         match self {
-            Self::Record(_) => "rec",
-            Self::Negation(_) => "not",
-            Self::ToInt(_) => "int",
-            Self::Negative(_) => "neg",
-            Self::Concat(_) => "cat",
-            Self::Eq(_) => "eq",
-            Self::NEq(_) => "neq",
-            Self::Gt(_) => "gt",
-            Self::Lt(_) => "lt",
-            Self::LtE(_) => "le",
-            Self::GtE(_) => "ge",
-            Self::And(_) => "and",
-            Self::Or(_) => "or",
-            Self::Matches(_) => "mtch",
-            Self::MatchesNot(_) => "nmtch",
-            Self::Add(_) => "add",
-            Self::Subtract(_) => "sub",
-            Self::Multiply(_) => "mul",
-            Self::Divide(_) => "div",
-            Self::Raise(_) => "pow",
-            Self::Modulo(_) => "mod",
-            Self::LoadUserScalar(_) => "vsload",
-            Self::LoadBuiltinScalar(_) => "isload",
-            Self::LoadUserArray(_) => "vaload",
-            Self::LoadUserMDimArray(_) => "vvload",
-            Self::LoadBuiltinArray(_) => "iaload",
-            Self::LoadConst(_) => "cload",
-            Self::StoreUserScalar(_) => "vsstore",
-            Self::StoreRecord(_) => "rsstore",
-            Self::StoreBuiltinScalar(_) => "isstore",
-            Self::StoreUserArray(_) => "vastore",
-            Self::StoreUserMDimArray(_) => "vvstore",
-            Self::StoreBuiltinArray(_) => "iastore",
-            Self::Copy(_) => "cpy",
-            Self::IntrinsicCall(_) => "icall",
-            Self::UserCall(_) => "ucall",
-            Self::IndirectCall(_) => "vcall",
-            Self::OutputCall(_) => "out",
-            Self::Jump(_) => "jmp",
-            Self::Return(_) => "ret",
-            Self::Branch(_) => "brif",
+            Self::Record { dest: _, arg: _, ty: _ } => "rec",
+            Self::Negation { dest: _, arg: _, ty: _ } => "not",
+            Self::ToInt { dest: _, arg: _, ty: _ } => "int",
+            Self::Negative { dest: _, arg: _, ty: _ } => "neg",
+            Self::Concat { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "cat",
+            Self::Eq { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "eq",
+            Self::NEq { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "neq",
+            Self::Gt { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "gt",
+            Self::Lt { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "lt",
+            Self::LtE { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "le",
+            Self::GtE { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "ge",
+            Self::And { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "and",
+            Self::Or { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "or",
+            Self::Matches { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "mtch",
+            Self::MatchesNot { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "nmtch",
+            Self::Add { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "add",
+            Self::Subtract { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "sub",
+            Self::Multiply { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "mul",
+            Self::Divide { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "div",
+            Self::Raise { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "pow",
+            Self::Modulo { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => "mod",
+            Self::StoreS { dest: _, ty_place: _, var: _, arg: _, ty: _ } => "sstore",
+            Self::StoreR { dest: _, src: _, arg: _, ty: _, tys: _ } => "rstore",
+            Self::StoreA {
+                dest: _,
+                ty_place: _,
+                start: _,
+                end: _,
+                var: _,
+                arg: _,
+            } => "astore",
+            Self::LoadA { dest: _, ty_place: _, start: _, end: _, var: _ } => "aload",
+            Self::Copy { dest: _, arg: _, ty: _ } => "cpy",
+            Self::IntrinsicCall { dest: _, start: _, end: _, name: _ } => "icall",
+            Self::UserCall { dest: _, start: _, end: _, name: _ } => "ucall",
+            Self::IndirectCall { dest: _, start: _, end: _, name: _, ty: _ } => "vcall",
+            Self::OutputCall { start: _, end: _, cmd: _, redir: _ } => "out",
+            Self::Jump { to: _ } => "jmp",
+            Self::Return { arg: _, ty: _ } => "ret",
+            Self::Branch { then_label: _, else_label: _, condition: _ } => "brif",
         }
     }
 }
 
 impl Display for Label {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         <_ as Display>::fmt(&self.0, f)
     }
 }
 
 impl Display for Reg {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "r{}", self.0)
     }
 }
 
 impl Display for NonLocal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         <_ as Display>::fmt(&self.0, f)
     }
 }
 
-impl Display for ArgCount {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <_ as Display>::fmt(&self.0, f)
-    }
-}
-
-impl Display for MaybeImm {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ArgTy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Reg(reg) => <_ as Display>::fmt(reg, f),
-            Self::Rec(rec) => write!(f, "rec[{rec}]"),
-            Self::Imm(imm) => write!(f, "imm({imm})"),
-            Self::ImmCnt(imm) => write!(f, "mem[{imm}]"),
-            Self::ImmUserVar(imm) => write!(f, "user[{imm}]"),
-            Self::ImmBuiltinVar(imm) => write!(f, "intrinsic[{imm}]"),
+            Self::Reg => write!(f, "r"),
+            Self::Imm => write!(f, "imm"),
+            Self::ImmF => write!(f, "immf"),
+            Self::Rec => write!(f, "$"),
+            Self::Cnt => write!(f, "mem"),
+            Self::UsVal => write!(f, "us"),
+            Self::UaVal => write!(f, "ua"),
+            Self::UmVal => write!(f, "um"),
+            Self::IsVal => write!(f, "is"),
+            Self::IaVal => write!(f, "ia"),
+            Self::ImVal => write!(f, "im"),
         }
     }
 }

--- a/interpreter/src/ir/lower.rs
+++ b/interpreter/src/ir/lower.rs
@@ -6,25 +6,25 @@
 use std::{borrow::Cow, mem::forget, ops::Deref};
 
 use bumpalo::{Bump, collections::Vec};
+use either::Either;
 use parser::{
-    Atom, BinaryOperator, BinaryPlaceOperator, Body, Expr, ExprNode, Place, SimpleStatement,
-    Statement, UnaryOperator, UnaryPlaceOperator, Variable,
+    Atom, BinaryOperator, BinaryPlaceOperator, Body, Expr, ExprNode, Identifier, Place,
+    SimpleStatement, Statement, UnaryOperator, UnaryPlaceOperator, Variable,
 };
 
 use crate::{
-    ir::{BinaryArg, Instruction, Label, MaybeImm, NonLocal, Reg, UnaryArg},
+    ir::{Arg, ArgTy, Instruction, IxWidth, Label, NonLocal, Reg, RegWidth},
     types::Value,
     vm::{Consts, ExecMode, Interpreter, SymbolTable},
 };
 
-#[derive(Debug)]
 pub struct Code<'arena> {
     pub arena: &'arena Bump,
     pub bc: Bytecode<'arena>,
     pub consts: Consts<'arena>,
     pub symbols: SymbolTable<'arena>,
     free_regs: Vec<'arena, Reg>,
-    pub reg_pointer: u8,
+    pub reg_pointer: RegWidth,
 }
 
 #[must_use]
@@ -32,10 +32,12 @@ pub struct Code<'arena> {
 #[repr(transparent)]
 struct LinearReg(Reg);
 
+#[derive(Clone, Copy)]
+struct TypedArg(Arg, ArgTy);
+
 #[must_use]
-#[derive(Debug)]
 enum Operand {
-    Imm(MaybeImm),
+    Imm(TypedArg),
     Reg(LinearReg),
 }
 
@@ -61,20 +63,21 @@ impl<'a> Code<'a> {
                 let cond_label = self.following_instr(0);
                 self.emit_branch(condition, |this| {
                     this.lower_body(then_body);
-                    this.bc.emit(Instruction::Jump(cond_label));
+                    this.bc.emit(Instruction::Jump { to: cond_label });
                 });
             }
             Statement::DoWhile { then_body, condition } => {
-                let do_label = self.following_instr(0);
+                let then_label = self.following_instr(0);
                 self.lower_body(then_body);
-                let condition = self.lower_expr(condition);
+                let cond_reg = self.alloc_reg();
+                self.lower_expr_into(condition, *cond_reg);
 
-                self.bc.emit(Instruction::Branch((
-                    condition.to_mi(),
-                    do_label,
-                    self.following_instr(1),
-                )));
-                condition.free(self);
+                self.bc.emit(Instruction::Branch {
+                    condition: *cond_reg,
+                    then_label,
+                    else_label: self.following_instr(1),
+                });
+                self.free_reg(cond_reg);
             }
             Statement::For { init, condition, update, body } => {
                 if let Some(SimpleStatement::Expression(expr)) = init {
@@ -88,21 +91,21 @@ impl<'a> Code<'a> {
                         if let Some(SimpleStatement::Expression(expr)) = update {
                             this.lower_expr(expr).free(this);
                         }
-                        this.bc.emit(Instruction::Jump(cond_label));
+                        this.bc.emit(Instruction::Jump { to: cond_label });
                     });
                 } else {
                     self.lower_body(body);
                     if let Some(SimpleStatement::Expression(expr)) = update {
                         self.lower_expr(expr).free(self);
                     }
-                    self.bc.emit(Instruction::Jump(cond_label));
+                    self.bc.emit(Instruction::Jump { to: cond_label });
                 }
             }
             Statement::Simple(SimpleStatement::Expression(expr)) => {
                 self.lower_expr(expr).free(self);
             }
             Statement::Simple(SimpleStatement::Command { name, args, redirection }) => {
-                let (call_start, call_end, redir) = self.gen_call_convention(args, |this| {
+                let (start, end, redir) = self.gen_call_convention(args, |this| {
                     redirection.as_ref().map(|(r, expr)| {
                         let redir_reg = this.alloc_reg();
                         this.lower_expr_into(expr, *redir_reg);
@@ -110,9 +113,8 @@ impl<'a> Code<'a> {
                         *r
                     })
                 });
-                self.bc.emit(Instruction::OutputCall((
-                    call_start, call_end, *name, redir,
-                )));
+                self.bc
+                    .emit(Instruction::OutputCall { start, end, cmd: *name, redir });
             }
             _ => todo!(),
         }
@@ -131,8 +133,9 @@ impl<'a> Code<'a> {
 
     fn lower_atom(&mut self, atom: &Atom) -> Operand {
         let dest = self.alloc_reg();
-        match self.lower_atom_mi(atom, *dest) {
-            MaybeImm::Reg(reg) => {
+        match self.lower_atom_arg(atom, *dest) {
+            TypedArg(arg, ArgTy::Reg) => {
+                let reg = unsafe { arg.reg };
                 debug_assert_eq!(reg, *dest);
                 Operand::Reg(dest)
             }
@@ -143,15 +146,12 @@ impl<'a> Code<'a> {
         }
     }
 
-    fn lower_atom_mi(&mut self, atom: &Atom, dest: Reg) -> MaybeImm {
+    fn lower_atom_arg(&mut self, atom: &Atom, dest: Reg) -> TypedArg {
         match atom {
-            Atom::Variable(Variable::User(ident)) => {
-                let src = self.symbols.register_user_var(ident, self.arena);
-                MaybeImm::from_vs(self, dest, src)
-            }
-            Atom::Variable(var) => MaybeImm::from_is(self, dest, var),
-            Atom::SmallInt(n) => MaybeImm::Imm(*n),
-            Atom::Number(n) => MaybeImm::from_cnt(self, dest, Value::Float(*n)),
+            Atom::Variable(Variable::User(ident)) => TypedArg::new_us(self, ident),
+            Atom::Variable(var) => TypedArg::new_is(var),
+            &Atom::Integer(n) => TypedArg::new_imm(n),
+            &Atom::Number(n) => TypedArg::new_immf(self, n),
             atom @ (Atom::String(s) | Atom::TypedRegex(s)) => {
                 let val = if matches!(atom, Atom::String(_)) {
                     Value::String
@@ -159,25 +159,26 @@ impl<'a> Code<'a> {
                     Value::Regex
                 };
                 let buf = self.arena.alloc_slice_copy(s.as_ref());
-                MaybeImm::from_cnt(self, dest, val(Cow::Borrowed(buf)))
+                TypedArg::new_cnt(self, val(Cow::Borrowed(buf)))
             }
             Atom::Regex(r) => {
                 let buf = &*self.arena.alloc_slice_copy(r.as_ref());
-                let rhs = MaybeImm::from_cnt(self, dest, Value::Regex(buf.into()));
+                let TypedArg(rhs, tyr) = TypedArg::new_cnt(self, Value::Regex(buf.into()));
+                let TypedArg(lhs, tyl) = TypedArg(Arg { imm: 0 }, ArgTy::Rec);
                 self.bc
-                    .emit(Instruction::Matches((dest, MaybeImm::Rec(0), rhs)));
-                MaybeImm::Reg(dest)
+                    .emit(Instruction::Matches { dest, rhs, lhs, tyr, tyl });
+                dest.into()
             }
             _ => todo!(),
         }
     }
 
     fn lower_atom_into(&mut self, atom: &Atom, dest: Reg) {
-        let mi = self.lower_atom_mi(atom, dest);
-        match mi {
-            MaybeImm::Reg(reg) if reg == dest => {}
-            other => {
-                self.bc.emit(Instruction::Copy((dest, other)));
+        let arg = self.lower_atom_arg(atom, dest);
+        match arg {
+            TypedArg(arg, ArgTy::Reg) if unsafe { arg.reg } == dest => {}
+            TypedArg(arg, ty) => {
+                self.bc.emit(Instruction::Copy { dest, arg, ty });
             }
         }
     }
@@ -188,53 +189,48 @@ impl<'a> Code<'a> {
             Expr::Node(node) => match node.as_ref() {
                 ExprNode::UnaryOperation(op, expr) => {
                     let src = self.lower_expr(expr);
-                    self.bc.emit(Instruction::from((*op, (dest, src.to_mi()))));
+                    self.bc
+                        .emit(Instruction::from_unary(*op, dest, src.to_arg()));
                     src.free(self);
                 }
                 ExprNode::BinaryOperation(op, lhs, rhs) => {
                     let lhs = self.lower_expr(lhs);
                     let rhs = self.lower_expr(rhs);
-                    self.bc
-                        .emit(Instruction::from((*op, (dest, lhs.to_mi(), rhs.to_mi()))));
+                    self.bc.emit(Instruction::from_binary(
+                        *op,
+                        dest,
+                        lhs.to_arg(),
+                        rhs.to_arg(),
+                    ));
                     lhs.free(self);
                     rhs.free(self);
                 }
                 ExprNode::Ternary(condition, true_then, false_then) => {
                     let (if_label, state) = self.emit_branch(condition, |this| {
                         RegsState::new(this)
-                            .scope(this, |this| {
-                                this.lower_expr_into(true_then, dest);
-                            })
+                            .scope(this, |this| this.lower_expr_into(true_then, dest))
                             .0
                     });
-
                     self.bc.nth(if_label).push_end_label();
                     self.emit_jump(|this| {
-                        state.scope_hwm(this, |this| {
-                            this.lower_expr_into(false_then, dest);
-                        });
+                        state.scope_hwm(this, |this| this.lower_expr_into(false_then, dest));
                     });
                 }
                 ExprNode::BinaryPlaceOperation(op, place, expr) => {
                     let val = self.lower_expr(expr);
 
-                    let second_op = match op {
-                        BinaryPlaceOperator::Assignment => {
-                            self.store_place(place, dest, val.to_mi());
-                            val.free(self);
-                            return;
-                        }
-                        BinaryPlaceOperator::AddAssign => Instruction::Add,
-                        BinaryPlaceOperator::SubAssign => Instruction::Subtract,
-                        BinaryPlaceOperator::MulAssign => Instruction::Multiply,
-                        BinaryPlaceOperator::DivAssign => Instruction::Divide,
-                        BinaryPlaceOperator::PowAssign => Instruction::Raise,
-                        BinaryPlaceOperator::ModAssign => Instruction::Modulo,
+                    let Some(bin_op) = lower_assign_ops(*op) else {
+                        self.store_place(place, dest, val.to_arg());
+                        val.free(self);
+                        return;
                     };
+
                     let lhs_reg = self.alloc_reg();
                     let lhs = self.load_place(*lhs_reg, place);
+                    let rhs = val.to_arg();
 
-                    self.bc.emit(second_op((dest, lhs, val.to_mi())));
+                    self.bc
+                        .emit(Instruction::from_binary(bin_op, dest, lhs, rhs));
                     self.store_place(place, dest, dest.into());
 
                     self.free_reg(lhs_reg);
@@ -242,26 +238,43 @@ impl<'a> Code<'a> {
                 }
                 ExprNode::UnaryPlaceOperation(op, place) => {
                     // Note: val may alias with dest.
-                    let val = self.load_place(dest, place);
+                    let lhs = self.load_place(dest, place);
+                    let one = TypedArg::new_imm(1);
 
-                    let second_op = match op {
-                        UnaryPlaceOperator::IncrementL | UnaryPlaceOperator::IncrementR => {
-                            Instruction::Add
-                        }
-                        UnaryPlaceOperator::DecrementL | UnaryPlaceOperator::DecrementR => {
-                            Instruction::Subtract
-                        }
-                    };
                     match op {
-                        UnaryPlaceOperator::IncrementL | UnaryPlaceOperator::DecrementL => {
-                            self.bc.emit(second_op((dest, val, MaybeImm::Imm(1))));
+                        UnaryPlaceOperator::IncrementL => {
+                            self.bc.emit(Instruction::from_binary(
+                                BinaryOperator::Add,
+                                dest,
+                                lhs,
+                                one,
+                            ));
+                            self.store_place(place, dest, dest.into());
+                        }
+                        UnaryPlaceOperator::DecrementL => {
+                            self.bc.emit(Instruction::from_binary(
+                                BinaryOperator::Subtract,
+                                dest,
+                                lhs,
+                                one,
+                            ));
                             self.store_place(place, dest, dest.into());
                         }
                         UnaryPlaceOperator::IncrementR | UnaryPlaceOperator::DecrementR => {
-                            self.bc
-                                .emit(Instruction::Add((dest, val, MaybeImm::Imm(0))));
+                            self.bc.emit(Instruction::from_binary(
+                                BinaryOperator::Add,
+                                dest,
+                                lhs,
+                                TypedArg::new_imm(0),
+                            ));
                             let tmp = self.alloc_reg();
-                            self.bc.emit(second_op((*tmp, val, MaybeImm::Imm(1))));
+                            let update_op = match op {
+                                UnaryPlaceOperator::IncrementR => BinaryOperator::Add,
+                                UnaryPlaceOperator::DecrementR => BinaryOperator::Subtract,
+                                _ => unreachable!(),
+                            };
+                            self.bc
+                                .emit(Instruction::from_binary(update_op, *tmp, lhs, one));
                             self.store_place(place, *tmp, (*tmp).into());
                             self.free_reg(tmp);
                         }
@@ -272,62 +285,78 @@ impl<'a> Code<'a> {
         }
     }
 
-    fn load_place(&mut self, dest: Reg, place: &Place<'_>) -> MaybeImm {
+    fn load_place(&mut self, dest: Reg, place: &Place<'_>) -> TypedArg {
         match place {
             Place::Record(_) => {
                 todo!()
             }
-            Place::Variable(Variable::User(ident)) => {
-                let src = self.symbols.register_user_var(ident, self.arena);
-                MaybeImm::from_vs(self, dest, src)
-            }
-            Place::Variable(var) => MaybeImm::from_is(self, dest, var),
+            Place::Variable(Variable::User(ident)) => TypedArg::new_us(self, ident),
+            Place::Variable(var) => TypedArg::new_is(var),
             Place::Index(Variable::User(ident), index) => {
-                let src = self.symbols.register_user_var(ident, self.arena);
+                let var = self.symbols.register_user_var(ident, self.arena);
                 let (start, end, _) = self.gen_call_convention(index, |_| ());
                 self.bc
-                    .emit(Instruction::LoadUserArray((dest, start, end, src)));
-                MaybeImm::Reg(dest)
+                    .emit(Instruction::LoadA { dest, ty_place: ArgTy::UaVal, start, end, var });
+                TypedArg(Arg { sym: var }, ArgTy::UaVal)
             }
             Place::Index(var, index) => {
                 let (start, end, _) = self.gen_call_convention(index, |_| ());
-                let index = var_index(var);
+                let var = var_index(var);
                 self.bc
-                    .emit(Instruction::LoadBuiltinArray((dest, start, end, index)));
-                MaybeImm::Reg(dest)
+                    .emit(Instruction::LoadA { dest, ty_place: ArgTy::UaVal, start, end, var });
+                TypedArg(Arg { sym: var }, ArgTy::IaVal)
             }
             Place::ChainedIndex(_, _) => todo!(),
         }
     }
 
-    fn store_place(&mut self, place: &Place<'_>, dest: Reg, src: MaybeImm) {
+    fn store_place(&mut self, place: &Place<'_>, dest: Reg, src: TypedArg) {
+        let TypedArg(arg, ty) = src;
         match place {
             Place::Record(expr) => {
                 let rec = self.lower_expr(expr);
+                let TypedArg(src, tys) = rec.to_arg();
                 self.bc
-                    .emit(Instruction::StoreRecord((dest, rec.to_mi(), src)));
+                    .emit(Instruction::StoreR { dest, src, tys, arg, ty });
                 rec.free(self);
             }
             Place::Variable(Variable::User(ident)) => {
                 let var = self.symbols.register_user_var(ident, self.arena);
-                self.bc.emit(Instruction::StoreUserScalar((dest, src, var)));
+                self.bc
+                    .emit(Instruction::StoreS { dest, ty_place: ArgTy::UsVal, var, arg, ty });
             }
             Place::Variable(var) => {
-                let index = var_index(var);
+                let var = var_index(var);
                 self.bc
-                    .emit(Instruction::StoreBuiltinScalar((dest, src, index)));
+                    .emit(Instruction::StoreS { dest, ty_place: ArgTy::IsVal, var, arg, ty });
             }
             Place::Index(Variable::User(ident), index) => {
-                let place = self.symbols.register_user_var(ident, self.arena);
+                let var = self.symbols.register_user_var(ident, self.arena);
                 let (start, end, _) = self.gen_call_convention(index, |_| ());
-                self.bc
-                    .emit(Instruction::StoreUserArray((dest, start, end, place)));
+                let arg = self.spill_to_reg(src);
+                self.bc.emit(Instruction::StoreA {
+                    dest,
+                    start,
+                    end,
+                    var,
+                    ty_place: ArgTy::UaVal,
+                    arg: arg.as_ref().either_into(),
+                });
+                arg.map_right(|r| self.free_reg(r));
             }
             Place::Index(var, index) => {
                 let (start, end, _) = self.gen_call_convention(index, |_| ());
-                let index = var_index(var);
-                self.bc
-                    .emit(Instruction::StoreBuiltinArray((dest, start, end, index)));
+                let var = var_index(var);
+                let arg = self.spill_to_reg(src);
+                self.bc.emit(Instruction::StoreA {
+                    dest,
+                    start,
+                    end,
+                    var,
+                    ty_place: ArgTy::IaVal,
+                    arg: arg.as_ref().either_into(),
+                });
+                arg.map_right(|r| self.free_reg(r));
             }
             Place::ChainedIndex(_, _) => todo!(),
         }
@@ -335,13 +364,14 @@ impl<'a> Code<'a> {
 
     fn emit_branch<T>(
         &mut self,
-        condition: &Expr<'_>,
+        condition_expr: &Expr<'_>,
         cb: impl FnOnce(&mut Self) -> T,
     ) -> (Label, T) {
-        let condition = self.lower_expr(condition);
+        let condition = self.alloc_reg();
+        self.lower_expr_into(condition_expr, *condition);
         let then_label = self.following_instr(1);
-        let if_label = self.bc.emit(Instruction::br(condition.to_mi(), then_label));
-        condition.free(self);
+        let if_label = self.bc.emit(Instruction::br(*condition, then_label));
+        self.free_reg(condition);
 
         let res = cb(self);
         let next = self.following_instr(0);
@@ -351,7 +381,7 @@ impl<'a> Code<'a> {
     }
 
     fn emit_jump<T>(&mut self, cb: impl FnOnce(&mut Self) -> T) -> T {
-        let label = self.bc.emit(Instruction::Jump(Label(0)));
+        let label = self.bc.emit(Instruction::Jump { to: Label(0) });
         let res = cb(self);
         let next = self.following_instr(0);
         self.bc.nth(label).set_label(next);
@@ -375,12 +405,12 @@ impl<'a> Code<'a> {
             .scope(self, |this| {
                 let call_start = this.reg_pointer;
                 // TODO: Nicer error reporting.
-                let args_len: u8 = args.len().try_into().expect("too many call args");
+                let args_len = RegWidth::try_from(args.len()).expect("too many call args");
                 let call_end = call_start.checked_add(args_len).expect("register overflow");
 
                 this.reg_pointer = call_end;
                 for (i, arg) in args.iter().enumerate() {
-                    let offset = i as u8;
+                    let offset = i as RegWidth;
                     let reg = Reg(call_start.checked_add(offset).expect("register overflow"));
                     this.lower_expr_into(arg, reg);
                 }
@@ -389,27 +419,37 @@ impl<'a> Code<'a> {
             .1
     }
 
+    fn spill_to_reg(&mut self, TypedArg(arg, ty): TypedArg) -> Either<Reg, LinearReg> {
+        if matches!(ty, ArgTy::Reg) {
+            Either::Left(unsafe { arg.reg })
+        } else {
+            let dest = self.alloc_reg();
+            self.bc.emit(Instruction::Copy { dest: *dest, arg, ty });
+            Either::Right(dest)
+        }
+    }
+
     fn free_reg(&mut self, reg: LinearReg) {
         self.free_regs.push(reg.into_inner());
     }
 
     fn register_const(&mut self, value: Value<'a>) -> NonLocal {
-        NonLocal(self.consts.0.insert_full(value).0 as u16)
+        NonLocal(self.consts.0.insert_full(value).0 as IxWidth)
     }
 
-    fn following_instr(&self, nth: u16) -> Label {
+    fn following_instr(&self, nth: IxWidth) -> Label {
         Label(self.bc.len() + nth)
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Bytecode<'a> {
     pub code: Vec<'a, Instruction>,
 }
 
 #[derive(Clone, Debug)]
 struct RegsState {
-    reg_pointer: u8,
+    reg_pointer: RegWidth,
     n_free_regs: usize,
 }
 
@@ -421,11 +461,11 @@ impl<'a> Bytecode<'a> {
     #[inline(always)]
     fn emit(&mut self, code: Instruction) -> Label {
         self.code.push(code);
-        Label((self.code.len() - 1) as u16)
+        Label((self.code.len() - 1) as IxWidth)
     }
 
-    fn len(&self) -> u16 {
-        self.code.len() as u16
+    fn len(&self) -> IxWidth {
+        self.code.len() as IxWidth
     }
 
     fn nth(&mut self, label: Label) -> &mut Instruction {
@@ -472,45 +512,55 @@ pub fn test_interpreter(stmnt: &Body<'_>) -> String {
     vm.to_string()
 }
 
-impl From<(UnaryOperator, UnaryArg)> for Instruction {
-    fn from((op, args): (UnaryOperator, UnaryArg)) -> Self {
-        match op {
-            UnaryOperator::Record => Self::Record(args),
-            UnaryOperator::Negation => Self::Negation(args),
-            UnaryOperator::ToInt => Self::ToInt(args),
-            UnaryOperator::Negative => Self::Negative(args),
-        }
+fn lower_assign_ops(op: BinaryPlaceOperator) -> Option<BinaryOperator> {
+    match op {
+        BinaryPlaceOperator::Assignment => None,
+        BinaryPlaceOperator::AddAssign => Some(BinaryOperator::Add),
+        BinaryPlaceOperator::SubAssign => Some(BinaryOperator::Subtract),
+        BinaryPlaceOperator::MulAssign => Some(BinaryOperator::Multiply),
+        BinaryPlaceOperator::DivAssign => Some(BinaryOperator::Divide),
+        BinaryPlaceOperator::PowAssign => Some(BinaryOperator::Raise),
+        BinaryPlaceOperator::ModAssign => Some(BinaryOperator::Modulo),
     }
 }
 
-impl From<(BinaryOperator, BinaryArg)> for Instruction {
-    fn from((op, args): (BinaryOperator, BinaryArg)) -> Self {
+impl Instruction {
+    fn from_unary(op: UnaryOperator, dest: Reg, TypedArg(arg, ty): TypedArg) -> Self {
         match op {
-            BinaryOperator::Concat => Self::Concat(args),
-            BinaryOperator::Eq => Self::Eq(args),
-            BinaryOperator::NEq => Self::NEq(args),
-            BinaryOperator::Gt => Self::Gt(args),
-            BinaryOperator::Lt => Self::Lt(args),
-            BinaryOperator::LtE => Self::LtE(args),
-            BinaryOperator::GtE => Self::GtE(args),
-            BinaryOperator::And => Self::And(args),
-            BinaryOperator::Or => Self::Or(args),
-            BinaryOperator::Matches => Self::Matches(args),
-            BinaryOperator::MatchesNot => Self::MatchesNot(args),
-            BinaryOperator::Add => Self::Add(args),
-            BinaryOperator::Subtract => Self::Subtract(args),
-            BinaryOperator::Multiply => Self::Multiply(args),
-            BinaryOperator::Divide => Self::Divide(args),
-            BinaryOperator::Raise => Self::Raise(args),
-            BinaryOperator::Modulo => Self::Modulo(args),
+            UnaryOperator::Record => Self::Record { dest, arg, ty },
+            UnaryOperator::Negation => Self::Negation { dest, arg, ty },
+            UnaryOperator::ToInt => Self::ToInt { dest, arg, ty },
+            UnaryOperator::Negative => Self::Negative { dest, arg, ty },
+        }
+    }
+
+    fn from_binary(
+        op: BinaryOperator,
+        dest: Reg,
+        TypedArg(lhs, tyl): TypedArg,
+        TypedArg(rhs, tyr): TypedArg,
+    ) -> Self {
+        match op {
+            BinaryOperator::Concat => Self::Concat { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Eq => Self::Eq { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::NEq => Self::NEq { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Gt => Self::Gt { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Lt => Self::Lt { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::LtE => Self::LtE { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::GtE => Self::GtE { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::And => Self::And { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Or => Self::Or { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Matches => Self::Matches { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::MatchesNot => Self::MatchesNot { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Add => Self::Add { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Subtract => Self::Subtract { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Multiply => Self::Multiply { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Divide => Self::Divide { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Raise => Self::Raise { dest, lhs, rhs, tyl, tyr },
+            BinaryOperator::Modulo => Self::Modulo { dest, lhs, rhs, tyl, tyr },
         }
     }
 }
-
-// trait Fold<T> {
-//     type Args;
-//     fn fold(&self, args: Self::Args) -> T;
-// }
 
 impl LinearReg {
     fn into_inner(self) -> Reg {
@@ -521,7 +571,7 @@ impl LinearReg {
 }
 
 impl Operand {
-    fn to_mi(&self) -> MaybeImm {
+    fn to_arg(&self) -> TypedArg {
         match self {
             &Self::Imm(imm) => imm,
             Self::Reg(reg) => reg.0.into(),
@@ -535,40 +585,34 @@ impl Operand {
     }
 }
 
-impl MaybeImm {
-    fn from_vs(code: &mut Code<'_>, dest: Reg, src: NonLocal) -> Self {
-        if let Ok(src) = u8::try_from(src.0) {
-            Self::ImmUserVar(src)
-        } else {
-            code.bc.emit(Instruction::LoadUserScalar((dest, src)));
-            Self::Reg(dest)
-        }
+impl TypedArg {
+    fn new_us(code: &mut Code<'_>, ident: &Identifier<'_>) -> Self {
+        let sym = code.symbols.register_user_var(ident, code.arena);
+        Self(Arg { sym }, ArgTy::UsVal)
     }
 
-    fn from_is(code: &mut Code<'_>, dest: Reg, var: &Variable<'_>) -> Self {
-        let src = var_index(var);
-        if let Ok(src) = u8::try_from(src.0) {
-            Self::ImmBuiltinVar(src)
-        } else {
-            code.bc.emit(Instruction::LoadBuiltinScalar((dest, src)));
-            Self::Reg(dest)
-        }
+    fn new_is(var: &Variable<'_>) -> Self {
+        Self(Arg { sym: var_index(var) }, ArgTy::IsVal)
     }
 
-    fn from_cnt<'a>(code: &mut Code<'a>, dest: Reg, value: Value<'a>) -> Self {
-        let src = code.register_const(value);
-        if let Ok(src) = u8::try_from(src.0) {
-            Self::ImmCnt(src)
-        } else {
-            code.bc.emit(Instruction::LoadConst((dest, src)));
-            Self::Reg(dest)
-        }
+    fn new_imm(imm: i32) -> Self {
+        Self(Arg { imm }, ArgTy::Imm)
+    }
+
+    fn new_immf(code: &mut Code<'_>, n: f64) -> Self {
+        let sym = code.register_const(Value::Float(n));
+        Self(Arg { sym }, ArgTy::ImmF)
+    }
+
+    fn new_cnt<'a>(code: &mut Code<'a>, val: Value<'a>) -> Self {
+        let sym = code.register_const(val);
+        Self(Arg { sym }, ArgTy::Cnt)
     }
 }
 
-impl From<Reg> for MaybeImm {
-    fn from(value: Reg) -> Self {
-        Self::Reg(value)
+impl From<Reg> for TypedArg {
+    fn from(reg: Reg) -> Self {
+        Self(Arg { reg }, ArgTy::Reg)
     }
 }
 
@@ -581,7 +625,7 @@ impl Deref for LinearReg {
 }
 
 fn var_index(var: &Variable<'_>) -> NonLocal {
-    // SAFETY: it is repr(u16).
+    // SAFETY: it is repr(RegWidth).
     unsafe { *<*const Variable>::from(var).cast::<NonLocal>() }
 }
 
@@ -589,5 +633,18 @@ fn var_index(var: &Variable<'_>) -> NonLocal {
 impl Drop for LinearReg {
     fn drop(&mut self) {
         debug_assert!(false, "Leaked register {}!", self.0);
+    }
+}
+
+impl From<&LinearReg> for Reg {
+    fn from(value: &LinearReg) -> Self {
+        **value
+    }
+}
+
+// HACK: Either::either_into from a ref.
+impl From<&Self> for Reg {
+    fn from(value: &Self) -> Self {
+        *value
     }
 }

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -2,7 +2,6 @@
 //
 // For the full copyright and license information, please view the LICENSE
 // files that was distributed with this source code.
-
 #![allow(dead_code)]
 
 pub(crate) mod ir;

--- a/interpreter/src/vm.rs
+++ b/interpreter/src/vm.rs
@@ -19,7 +19,7 @@ use parser::{Command, Identifier, Redirection};
 
 use crate::{
     ir::{
-        Instruction, Label, MaybeImm, NonLocal, Reg,
+        Instruction, Label, NonLocal, Reg,
         lower::{Bytecode, Code},
     },
     types::Value,
@@ -32,7 +32,6 @@ pub enum ExecMode {
     Posix,
 }
 
-#[derive(Debug)]
 pub struct Interpreter<'a> {
     arena: &'a Bump,
     bc: Bytecode<'a>,
@@ -121,20 +120,25 @@ impl<'a> Consts<'a> {
 impl Interpreter<'_> {
     pub fn run(&mut self) {
         macro_rules! rx {
-            ($self:expr, $dest:expr, $src:ident, $e:expr) => {{
-                rx!($self, $src);
+            ($self:expr, $dest:expr, $src:ident: $ty:ident, $e:expr) => {{
+                rx!($self, $src: $ty);
                 $self.registers.write($dest, $e);
             }};
-            ($self:expr, $($src:ident),+) => {
-                $(let $src = match $src {
-                    MaybeImm::Reg(src) => $self.registers.get(src),
-                    MaybeImm::Rec(_) => todo!(),
-                    MaybeImm::Imm(src) => &Value::Int(src.into()),
-                    MaybeImm::ImmCnt(src) => &$self.consts.0.get_index(src as _).unwrap().clone(),
-                    MaybeImm::ImmUserVar(src) => {
-                        &$self.symbols.lookup_user_scalar(NonLocal(src.into())).clone()
+            ($self:expr, $dest:expr, $lhs:ident: $tyl:ident, $rhs:ident: $tyr:ident, $e:expr) => {{
+                rx!($self, $lhs: $tyl, $rhs: $tyr);
+                $self.registers.write($dest, $e);
+            }};
+            ($self:expr, $($src:ident: $ty:ident),+) => {
+                use $crate::ir::ArgTy;
+                $(let $src = match $ty {
+                    ArgTy::Reg => $self.registers.get(unsafe { $src.reg }),
+                    ArgTy::Rec => todo!(),
+                    ArgTy::Imm => &Value::Int(unsafe { $src.imm } as _),
+                    ArgTy::Cnt => &$self.consts.0.get_index(unsafe { $src.sym.0 } as _).unwrap().clone(),
+                    ArgTy::UsVal => {
+                        &$self.symbols.lookup_user_scalar(unsafe { $src.sym }).clone()
                     }
-                    MaybeImm::ImmBuiltinVar(_) => todo!(),
+                    _ => todo!()
                 };)+
             };
             ($self:expr, $dest:expr, $lhs:ident, $rhs:ident, $e:expr) => {{
@@ -144,92 +148,102 @@ impl Interpreter<'_> {
         }
         while let Some(&instr) = self.bc.code.get(self.program_counter) {
             match instr {
-                Instruction::Record(_) => todo!(),
-                Instruction::Negation((dest, src)) => {
-                    rx!(self, dest, src, Value::b2f(!src.to_bool()));
+                Instruction::Record { dest: _, arg: _, ty: _ } => todo!(),
+                Instruction::Negation { dest, arg, ty } => {
+                    rx!(self, dest, arg: ty, Value::b2f(!arg.to_bool()));
                 }
-                Instruction::ToInt((dest, src)) => {
-                    rx!(self, dest, src, Value::Float(src.to_num().trunc()));
+                Instruction::ToInt { dest, arg, ty } => {
+                    rx!(self, dest, arg: ty, Value::Float(arg.to_num().trunc()));
                 }
-                Instruction::Negative((dest, src)) => {
-                    rx!(self, dest, src, Value::Float(-src.to_num()));
+                Instruction::Negative { dest, arg, ty } => {
+                    rx!(self, dest, arg: ty, Value::Float(-arg.to_num()));
                 }
-                Instruction::Copy((dest, src)) => rx!(self, dest, src, src.clone()),
-                Instruction::Eq((dest, lhs, rhs)) => {
-                    rx!(self, dest, lhs, rhs, Value::b2f(lhs == rhs));
+                Instruction::Copy { dest, arg, ty } => rx!(self, dest, arg: ty, arg.clone()),
+                Instruction::Eq { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, Value::b2f(lhs == rhs));
                 }
-                Instruction::NEq((dest, lhs, rhs)) => {
-                    rx!(self, dest, lhs, rhs, Value::b2f(lhs != rhs));
+                Instruction::NEq { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, Value::b2f(lhs != rhs));
                 }
-                Instruction::Gt((dest, lhs, rhs)) => {
-                    rx!(self, dest, lhs, rhs, Value::b2f(lhs > rhs));
+                Instruction::Gt { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, Value::b2f(lhs > rhs));
                 }
-                Instruction::Lt((dest, lhs, rhs)) => {
-                    rx!(self, dest, lhs, rhs, Value::b2f(lhs < rhs));
+                Instruction::Lt { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, Value::b2f(lhs < rhs));
                 }
-                Instruction::LtE((dest, lhs, rhs)) => {
-                    rx!(self, dest, lhs, rhs, Value::b2f(lhs <= rhs));
+                Instruction::LtE { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, Value::b2f(lhs <= rhs));
                 }
-                Instruction::GtE((dest, lhs, rhs)) => {
-                    rx!(self, dest, lhs, rhs, Value::b2f(lhs >= rhs));
+                Instruction::GtE { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, Value::b2f(lhs >= rhs));
                 }
-                Instruction::And((_dest, _lhs, _rhs)) => todo!(),
-                Instruction::Or((_dest, _lhs, _rhs)) => todo!(),
-                Instruction::Matches((_dest, _lhs, _rhs)) => todo!(),
-                Instruction::MatchesNot((_dest, _lhs, _rhs)) => todo!(),
-                Instruction::Add((dest, lhs, rhs)) => rx!(self, dest, lhs, rhs, lhs + rhs),
-                Instruction::Subtract((dest, lhs, rhs)) => rx!(self, dest, lhs, rhs, lhs - rhs),
-                Instruction::Multiply((dest, lhs, rhs)) => rx!(self, dest, lhs, rhs, lhs * rhs),
-                Instruction::Divide((dest, lhs, rhs)) => rx!(self, dest, lhs, rhs, lhs / rhs),
-                Instruction::Raise((dest, lhs, rhs)) => rx!(self, dest, lhs, rhs, lhs ^ rhs),
-                Instruction::Modulo((dest, lhs, rhs)) => rx!(self, dest, lhs, rhs, lhs % rhs),
-                Instruction::Concat((dest, lhs, rhs)) => {
-                    rx!(self, lhs, rhs);
+                Instruction::And { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
+                Instruction::Or { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
+                Instruction::Matches { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
+                Instruction::MatchesNot { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
+                Instruction::Add { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, lhs + rhs);
+                }
+                Instruction::Subtract { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, lhs - rhs);
+                }
+                Instruction::Multiply { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, lhs * rhs);
+                }
+                Instruction::Divide { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, lhs / rhs);
+                }
+                Instruction::Raise { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, lhs ^ rhs);
+                }
+                Instruction::Modulo { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, dest, lhs: tyl, rhs: tyr, lhs % rhs);
+                }
+                Instruction::Concat { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, lhs: tyl, rhs: tyr);
                     let mut buf =
                         StdVec::with_capacity(lhs.string_size_hint() + rhs.string_size_hint());
                     lhs.write_string(&mut buf);
                     rhs.write_string(&mut buf);
                     self.registers.write(dest, Value::String(buf.into()));
                 }
-                Instruction::LoadUserScalar((dest, src)) => {
-                    let val = self.symbols.lookup_user_scalar(src);
-                    self.registers.write(dest, val.clone());
+                Instruction::LoadA { dest: _, ty_place: _, start: _, end: _, var: _ } => todo!(),
+                Instruction::StoreS { dest, ty_place, var, arg, ty } => {
+                    rx!(self, arg: ty);
+                    match ty_place {
+                        ArgTy::UsVal => self.symbols.write_user_val(var, arg.clone()),
+                        ArgTy::IsVal => todo!(),
+                        _ => unreachable!(),
+                    }
+                    self.registers.write(dest, arg.clone());
                 }
-                Instruction::LoadUserArray((_dest, _start, _end, _src)) => todo!(),
-                Instruction::LoadUserMDimArray((_dest, _start, _end, _place)) => todo!(),
-                Instruction::LoadBuiltinScalar((_dest, _src)) => todo!(),
-                Instruction::LoadBuiltinArray((_dest, _src, _start, _end)) => todo!(),
-                Instruction::LoadConst((dest, src)) => {
-                    let val = self.consts.0.get_index(src.0 as _).unwrap().clone();
-                    self.registers.write(dest, val);
+                Instruction::StoreR { dest: _, src: _, arg: _, ty: _, tys: _ } => {
+                    todo!()
                 }
-                Instruction::StoreUserScalar((dest, imm, src)) => {
-                    rx!(self, imm);
-                    self.symbols.write_user_val(src, imm.clone());
-                    self.registers.write(dest, imm.clone());
+                Instruction::StoreA {
+                    dest: _,
+                    ty_place: _,
+                    start: _,
+                    end: _,
+                    var: _,
+                    arg: _,
+                } => todo!(),
+                Instruction::IntrinsicCall { dest: _, start: _, end: _, name: _ } => todo!(),
+                Instruction::OutputCall { start, end, cmd, redir } => {
+                    self.intrinsic_print(start, end, cmd, redir);
                 }
-                Instruction::StoreUserArray((_dest, _src, _start, _end)) => todo!(),
-                Instruction::StoreUserMDimArray((_dest, _start, _end, _place)) => todo!(),
-                Instruction::StoreRecord(_) => todo!(),
-                Instruction::StoreBuiltinScalar((_dest, _imm, _src)) => todo!(),
-                Instruction::StoreBuiltinArray((_dest, _src, _start, _end)) => todo!(),
-                Instruction::IntrinsicCall((_dest, _start, _end, _fun)) => todo!(),
-                Instruction::OutputCall((start, end, fun, redir)) => {
-                    self.intrinsic_print(start, end, fun, redir);
-                }
-                Instruction::UserCall((_dest, _start, _end, _fun)) => todo!(),
-                Instruction::IndirectCall((_dest, _start, _end, _fun)) => todo!(),
-                Instruction::Jump(Label(label)) => {
+                Instruction::UserCall { dest: _, start: _, end: _, name: _ } => todo!(),
+                Instruction::IndirectCall { dest: _, start: _, end: _, name: _, ty: _ } => todo!(),
+                Instruction::Jump { to: Label(label) } => {
                     self.program_counter = label as _;
                     continue;
                 }
-                Instruction::Return(_src) => todo!(),
-                Instruction::Branch((src, Label(true_to), Label(false_to))) => {
-                    rx!(self, src);
-                    if src.to_bool() {
-                        self.program_counter = true_to as _;
+                Instruction::Return { arg: _, ty: _ } => todo!(),
+                Instruction::Branch { then_label, else_label, condition } => {
+                    if self.registers.get(condition).to_bool() {
+                        self.program_counter = then_label.0 as _;
                     } else {
-                        self.program_counter = false_to as _;
+                        self.program_counter = else_label.0 as _;
                     }
                     continue;
                 }

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -23,7 +23,6 @@ use thiserror::Error;
 pub type Lexer<'a> = logos::Lexer<'a, Token<'a>>;
 pub type Result<T, E = LexingError> = std::result::Result<T, E>;
 
-// TODO: check wnat GNU does about potentially reserved `@ident`; add error branch if so.
 #[derive(Logos, Debug, PartialEq)]
 #[logos(utf8 = false)]
 #[logos(skip(r"(?&ignore)"))]
@@ -34,8 +33,10 @@ pub type Result<T, E = LexingError> = std::result::Result<T, E>;
 #[logos(subpattern ignore_with_nl = r"(?:(?&ignore)|\n)*")]
 #[logos(error(LexingError, callback = |lex| LexingError::unexpected(lex)))]
 pub enum Token<'a> {
-    #[regex("(-128|(-)?(12[0-7]|1[01][0-9]|[1-9]?[0-9]))", parse_i8, priority = 9)]
-    SmallInt(i8),
+    #[regex(r"(-)?\d+", parse_num, priority = 9)]
+    Numeric,
+    // Not emitted by Logos directly.
+    Integer(i32),
     #[regex(r"(-)?[0-9]+(\.[0-9]*)?([eE][+-]?[0-9]+)?", parse_float, priority = 8)]
     #[regex(r"\.[0-9]+([eE][+-]?[0-9]+)?", parse_float)]
     Number(f64),
@@ -484,9 +485,12 @@ fn parse_float(lex: &mut Lexer<'_>) -> f64 {
     parse_ident(lex, ..).parse().unwrap_or(0.)
 }
 
-fn parse_i8(lex: &mut Lexer<'_>) -> i8 {
-    // SAFETY: The regex matchin ensures it is well-formed and in [-128, 127].
-    unsafe { parse_ident(lex, ..).parse().unwrap_unchecked() }
+fn parse_num<'a>(lex: &mut Lexer<'a>) -> Token<'a> {
+    if let Ok(num) = parse_ident(lex, ..).parse() {
+        Token::Integer(num)
+    } else {
+        Token::Number(parse_float(lex))
+    }
 }
 
 fn parse_non_posix_keyword<'a>(lex: &mut Lexer<'a>, other: Token<'a>) -> Token<'a> {

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -101,6 +101,82 @@ pub enum Token<'a> {
     #[token("function", accept_expression)]
     #[token("func", |lex| parse_non_posix_keyword(lex, Token::Function))]
     Function,
+    #[token("length", accept_expression)]
+    Length,
+    #[token("substr", accept_expression)]
+    Substr,
+    #[token("split", accept_expression)]
+    Split,
+    #[token("sub", accept_expression)]
+    Sub,
+    #[token("gsub", accept_expression)]
+    Gsub,
+    #[token("match", accept_expression)]
+    MatchFn,
+    #[token("index", accept_expression)]
+    Index,
+    #[token("sprintf", accept_expression)]
+    Sprintf,
+    #[token("toupper", accept_expression)]
+    Toupper,
+    #[token("tolower", accept_expression)]
+    Tolower,
+    #[token("gensub", |lex| parse_non_posix_keyword(lex, Token::Gensub))]
+    Gensub,
+    #[token("patsplit", |lex| parse_non_posix_keyword(lex, Token::Patsplit))]
+    Patsplit,
+    #[token("strtonum", |lex| parse_non_posix_keyword(lex, Token::Strtonum))]
+    Strtonum,
+    #[token("close", accept_expression)]
+    Close,
+    #[token("fflush", accept_expression)]
+    Fflush,
+    #[token("system", accept_expression)]
+    System,
+    #[token("int", accept_expression)]
+    Int,
+    #[token("sqrt", accept_expression)]
+    Sqrt,
+    #[token("exp", accept_expression)]
+    Exp,
+    #[token("log", accept_expression)]
+    Log,
+    #[token("sin", accept_expression)]
+    Sin,
+    #[token("cos", accept_expression)]
+    Cos,
+    #[token("atan2", accept_expression)]
+    Atan2,
+    #[token("rand", accept_expression)]
+    Rand,
+    #[token("srand", accept_expression)]
+    Srand,
+    #[token("systime", |lex| parse_non_posix_keyword(lex, Token::Systime))]
+    Systime,
+    #[token("mktime", |lex| parse_non_posix_keyword(lex, Token::Mktime))]
+    Mktime,
+    #[token("strftime", |lex| parse_non_posix_keyword(lex, Token::Strftime))]
+    Strftime,
+    #[token("typeof", |lex| parse_non_posix_keyword(lex, Token::Typeof))]
+    Typeof,
+    #[token("isarray", |lex| parse_non_posix_keyword(lex, Token::Isarray))]
+    Isarray,
+    #[token("asort", |lex| parse_non_posix_keyword(lex, Token::Asort))]
+    Asort,
+    #[token("asorti", |lex| parse_non_posix_keyword(lex, Token::Asorti))]
+    Asorti,
+    #[token("and", |lex| parse_non_posix_keyword(lex, Token::And))]
+    And,
+    #[token("or", |lex| parse_non_posix_keyword(lex, Token::Or))]
+    Or,
+    #[token("xor", |lex| parse_non_posix_keyword(lex, Token::Xor))]
+    Xor,
+    #[token("compl", |lex| parse_non_posix_keyword(lex, Token::Compl))]
+    Compl,
+    #[token("lshift", |lex| parse_non_posix_keyword(lex, Token::Lshift))]
+    Lshift,
+    #[token("rshift", |lex| parse_non_posix_keyword(lex, Token::Rshift))]
+    Rshift,
     #[token("NR", accept_expression)]
     NrVariable,
     #[token("NF", accept_expression)]

--- a/lexer/src/tests.rs
+++ b/lexer/src/tests.rs
@@ -123,11 +123,11 @@ fn lexer_test_gnu_pattern() {
 #[test]
 fn lexer_test_nums() {
     let arena = Bump::new();
-    let str = b"1 20. 0. .3 2e4 -3.e2 5e+1 2.1e-3 -129 -128 -0 127 128";
+    let str = b"1 20. 0. .3 2e4 -3.e2 5e+1 2.1e-3 -2147483649 -128 -0 127 2147483648";
     assert_eq!(
         &lex(str, &arena, false, false),
         &[
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::Number(20.),
             Token::Number(0.),
             Token::Number(0.3),
@@ -135,11 +135,11 @@ fn lexer_test_nums() {
             Token::Number(-3e2),
             Token::Number(5e1),
             Token::Number(2.1e-3),
-            Token::Number(-129.),
-            Token::SmallInt(-128),
-            Token::SmallInt(0),
-            Token::SmallInt(127),
-            Token::Number(128.)
+            Token::Number(-2_147_483_649.),
+            Token::Integer(-128),
+            Token::Integer(0),
+            Token::Integer(127),
+            Token::Number(2_147_483_648.)
         ]
     );
 }
@@ -165,12 +165,12 @@ fn lexer_test_ident_rules_non_posix() {
     assert_eq!(
         &lex(b"1a::a a::1a _a", &arena, false, false),
         &[
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::Identifier(Identifier { namespace: Some("a"), literal: "a" }),
             Token::Identifier(Identifier { namespace: None, literal: "a" }),
             Token::Colon,
             Token::Colon,
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::Identifier(Identifier { namespace: None, literal: "a" }),
             Token::Identifier(Identifier { namespace: None, literal: "_a" })
         ]
@@ -205,7 +205,7 @@ fn lexer_test_general_tokens() {
             Token::Print,
             Token::Identifier(Identifier { namespace: None, literal: "a" }),
             Token::Plus,
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::ClosedBrace,
             Token::Newline,
             Token::Regex(b"2\\..*".into()),
@@ -214,7 +214,7 @@ fn lexer_test_general_tokens() {
             Token::EndPattern,
             Token::OpenBrace,
             Token::Record,
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::EqualTo,
             Token::Identifier(Identifier { namespace: Some("foo"), literal: "bar" }),
             Token::ClosedBrace,
@@ -229,12 +229,12 @@ fn lexer_test_regex_ambiguity() {
     assert_eq!(
         &lex(b"1/=1. a/=1", &arena, false, false),
         &[
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::SlashAssign,
             Token::Number(1.),
             Token::Identifier(Identifier { namespace: None, literal: "a" }),
             Token::SlashAssign,
-            Token::SmallInt(1)
+            Token::Integer(1)
         ]
     );
 }

--- a/lexer/src/tests.rs
+++ b/lexer/src/tests.rs
@@ -396,7 +396,7 @@ fn lexer_test_slash_assign() {
         &[
             Token::Identifier(Identifier { namespace: None, literal: "a" }),
             Token::SlashAssign,
-            Token::SmallInt(1),
+            Token::Integer(1),
         ]
     );
 }
@@ -468,10 +468,10 @@ fn lexer_test_comments() {
         &lex(str, &arena, false, false),
         &[
             Token::Print,
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::Newline,
             Token::Print,
-            Token::SmallInt(2),
+            Token::Integer(2),
         ]
     );
 }
@@ -542,7 +542,7 @@ fn lexer_test_regex_literals() {
 #[test]
 fn lexer_test_switch_snippet() {
     let arena = Bump::new();
-    let str = br#"switch (x) { case 1: print; default: break }"#;
+    let str = br"switch (x) { case 1: print; default: break }";
     assert_eq!(
         &lex(str, &arena, false, false),
         &[
@@ -552,7 +552,7 @@ fn lexer_test_switch_snippet() {
             Token::ClosedParent,
             Token::OpenBrace,
             Token::Case,
-            Token::SmallInt(1),
+            Token::Integer(1),
             Token::Colon,
             Token::Print,
             Token::Semicolon,

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -35,7 +35,7 @@ pub struct Rule<'a> {
 pub enum Atom<'a> {
     Variable(Variable<'a>),
     String(Slice<'a>),
-    SmallInt(i8),
+    Integer(i32),
     Number(f64),
     BigInt(),
     BigFloat(),

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -96,6 +96,7 @@ pub type Pattern<'a> = Either<RulePattern<'a>, SpecialPattern>;
 pub enum ExprNode<'a> {
     FunctionCall(Identifier<'a>, Vec<'a, Expr<'a>>),
     IndirectCall(Variable<'a>, Vec<'a, Expr<'a>>),
+    BuiltinCall(BuiltinFunction, Vec<'a, Expr<'a>>),
     UnaryOperation(UnaryOperator, Expr<'a>),
     BinaryOperation(BinaryOperator, Expr<'a>, Expr<'a>),
     UnaryPlaceOperation(UnaryPlaceOperator, Place<'a>),
@@ -250,6 +251,49 @@ pub enum SimpleStatement<'a> {
 pub struct Function<'a> {
     pub args: Vec<'a, Identifier<'a>>,
     pub body: Body<'a>,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum BuiltinFunction {
+    Length,
+    Substr,
+    Split,
+    Sub,
+    Gsub,
+    Match,
+    Index,
+    Sprintf,
+    Toupper,
+    Tolower,
+    Gensub,
+    Patsplit,
+    Strtonum,
+    Close,
+    Fflush,
+    System,
+    Int,
+    Sqrt,
+    Exp,
+    Log,
+    Sin,
+    Cos,
+    Atan2,
+    Rand,
+    Srand,
+    Systime,
+    Mktime,
+    Strftime,
+    Typeof,
+    Isarray,
+    Asort,
+    Asorti,
+    And,
+    Or,
+    Xor,
+    Compl,
+    Lshift,
+    Rshift,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/parser/src/idempotency.rs
+++ b/parser/src/idempotency.rs
@@ -6,7 +6,7 @@
 use std::fmt::{Debug, Display, Formatter, Result, Write};
 
 use crate::{
-    Ast, Function,
+    Ast, BuiltinFunction, Function,
     ast::{
         ArrayOperator, Atom, BinaryOperator, BinaryPlaceOperator, BindingPower, Body, Command,
         Expr, ExprNode, Getline, Place, Redirection, Rule, RulePattern, SimpleStatement, Statement,
@@ -264,6 +264,11 @@ impl Display for ExprNode<'_> {
                 write_args(f, args, indent)?;
                 write!(f, ")")
             }
+            Self::BuiltinCall(fun, args) => {
+                write!(f, "{fun}(")?;
+                write_args(f, args, indent)?;
+                write!(f, ")")
+            }
             Self::UnaryOperation(op, x) => {
                 let bp = op.binding_power();
                 let child_w = encode(indent, bp.saturating_add(1));
@@ -421,6 +426,52 @@ impl Display for Command {
             Self::Print => write!(f, "print"),
             Self::Printf => write!(f, "printf"),
         }
+    }
+}
+
+impl Display for BuiltinFunction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let name = match self {
+            Self::Length => "length",
+            Self::Substr => "substr",
+            Self::Split => "split",
+            Self::Sub => "sub",
+            Self::Gsub => "gsub",
+            Self::Match => "match",
+            Self::Index => "index",
+            Self::Sprintf => "sprintf",
+            Self::Toupper => "toupper",
+            Self::Tolower => "tolower",
+            Self::Gensub => "gensub",
+            Self::Patsplit => "patsplit",
+            Self::Strtonum => "strtonum",
+            Self::Close => "close",
+            Self::Fflush => "fflush",
+            Self::System => "system",
+            Self::Int => "int",
+            Self::Sqrt => "sqrt",
+            Self::Exp => "exp",
+            Self::Log => "log",
+            Self::Sin => "sin",
+            Self::Cos => "cos",
+            Self::Atan2 => "atan2",
+            Self::Rand => "rand",
+            Self::Srand => "srand",
+            Self::Systime => "systime",
+            Self::Mktime => "mktime",
+            Self::Strftime => "strftime",
+            Self::Typeof => "typeof",
+            Self::Isarray => "isarray",
+            Self::Asort => "asort",
+            Self::Asorti => "asorti",
+            Self::And => "and",
+            Self::Or => "or",
+            Self::Xor => "xor",
+            Self::Compl => "compl",
+            Self::Lshift => "lshift",
+            Self::Rshift => "rshift",
+        };
+        write!(f, "{name}")
     }
 }
 

--- a/parser/src/lex.rs
+++ b/parser/src/lex.rs
@@ -221,7 +221,7 @@ impl TokenExt for Token<'_> {
     fn is_atom(&self) -> bool {
         matches!(
             self,
-            Token::Number(_) | Token::SmallInt(_) | Token::String(_) | Token::Regex(_)
+            Token::Number(_) | Token::Integer(_) | Token::String(_) | Token::Regex(_)
         ) || self.is_place() && self != &Token::Record
     }
     fn is_expr_start(&self) -> bool {

--- a/parser/src/lex.rs
+++ b/parser/src/lex.rs
@@ -11,7 +11,7 @@ use lexer::{Identifier, LexingError, Slice, Span, SpannedIter, Token};
 use super::Result;
 use crate::{
     ParsingError,
-    ast::{Command, SpecialPattern},
+    ast::{BuiltinFunction, Command, SpecialPattern},
 };
 
 pub struct Lexer<'a> {
@@ -200,6 +200,7 @@ pub trait TokenExt {
     fn is_place(&self) -> bool;
     fn is_pattern_start(&self) -> bool;
     fn maps_to_command(&self) -> Option<Command>;
+    fn maps_to_builtin(&self) -> Option<BuiltinFunction>;
     fn maps_to_special_pat(&self) -> Option<SpecialPattern>;
     fn is_stmnt_end(&self) -> bool;
     fn is_stmnt_or_block_end(&self) -> bool;
@@ -261,6 +262,50 @@ impl TokenExt for Token<'_> {
         match self {
             Token::Print => Some(Command::Print),
             Token::Printf => Some(Command::Printf),
+            _ => None,
+        }
+    }
+
+    fn maps_to_builtin(&self) -> Option<BuiltinFunction> {
+        match self {
+            Token::Length => Some(BuiltinFunction::Length),
+            Token::Substr => Some(BuiltinFunction::Substr),
+            Token::Split => Some(BuiltinFunction::Split),
+            Token::Sub => Some(BuiltinFunction::Sub),
+            Token::Gsub => Some(BuiltinFunction::Gsub),
+            Token::MatchFn => Some(BuiltinFunction::Match),
+            Token::Index => Some(BuiltinFunction::Index),
+            Token::Sprintf => Some(BuiltinFunction::Sprintf),
+            Token::Toupper => Some(BuiltinFunction::Toupper),
+            Token::Tolower => Some(BuiltinFunction::Tolower),
+            Token::Gensub => Some(BuiltinFunction::Gensub),
+            Token::Patsplit => Some(BuiltinFunction::Patsplit),
+            Token::Strtonum => Some(BuiltinFunction::Strtonum),
+            Token::Close => Some(BuiltinFunction::Close),
+            Token::Fflush => Some(BuiltinFunction::Fflush),
+            Token::System => Some(BuiltinFunction::System),
+            Token::Int => Some(BuiltinFunction::Int),
+            Token::Sqrt => Some(BuiltinFunction::Sqrt),
+            Token::Exp => Some(BuiltinFunction::Exp),
+            Token::Log => Some(BuiltinFunction::Log),
+            Token::Sin => Some(BuiltinFunction::Sin),
+            Token::Cos => Some(BuiltinFunction::Cos),
+            Token::Atan2 => Some(BuiltinFunction::Atan2),
+            Token::Rand => Some(BuiltinFunction::Rand),
+            Token::Srand => Some(BuiltinFunction::Srand),
+            Token::Systime => Some(BuiltinFunction::Systime),
+            Token::Mktime => Some(BuiltinFunction::Mktime),
+            Token::Strftime => Some(BuiltinFunction::Strftime),
+            Token::Typeof => Some(BuiltinFunction::Typeof),
+            Token::Isarray => Some(BuiltinFunction::Isarray),
+            Token::Asort => Some(BuiltinFunction::Asort),
+            Token::Asorti => Some(BuiltinFunction::Asorti),
+            Token::And => Some(BuiltinFunction::And),
+            Token::Or => Some(BuiltinFunction::Or),
+            Token::Xor => Some(BuiltinFunction::Xor),
+            Token::Compl => Some(BuiltinFunction::Compl),
+            Token::Lshift => Some(BuiltinFunction::Lshift),
+            Token::Rshift => Some(BuiltinFunction::Rshift),
             _ => None,
         }
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -636,7 +636,7 @@ impl<'a> Parser<'a> {
     ) -> Result<Atom<'a>> {
         match token {
             Token::Number(n) => Ok(Atom::Number(n)),
-            Token::SmallInt(n) => Ok(Atom::SmallInt(n)),
+            Token::Integer(n) => Ok(Atom::Integer(n)),
             Token::String(s) => Ok(Atom::String(s)),
             Token::Regex(r) => Ok(Atom::Regex(r)),
             Token::TypedRegex(r) if typed_regex => Ok(Atom::TypedRegex(r)),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -235,6 +235,10 @@ impl<'a> Parser<'a> {
                     lex.next();
                     Some(self.parse_command(lex, name))
                 }
+                token if let Some(builtin) = token.maps_to_builtin() => {
+                    lex.next();
+                    Some(self.parse_builtin_call(lex, builtin))
+                }
                 Token::Delete => {
                     lex.next();
                     Some(self.parse_delete(lex))
@@ -479,6 +483,17 @@ impl<'a> Parser<'a> {
         };
         let redirection = self.parse_command_redirection(lex)?;
         Ok(SimpleStatement::Command { name, args, redirection })
+    }
+
+    #[tracing::instrument]
+    fn parse_builtin_call(
+        &mut self,
+        lex: &mut Lexer<'a>,
+        builtin: BuiltinFunction,
+    ) -> Result<SimpleStatement<'a>> {
+        let expr =
+            self.parse_function_call(lex, |args| ExprNode::BuiltinCall(builtin, args), lex.span())?;
+        Ok(SimpleStatement::Expression(expr))
     }
 
     /// Parses arguments to command or function calls; consumes to the end of

--- a/parser/src/pratt.rs
+++ b/parser/src/pratt.rs
@@ -274,6 +274,12 @@ impl<'a, 'b> Pratt<'a, 'b> {
                 |args| ExprNode::FunctionCall(name.qualify(self.parser.namespace), args),
                 lex.span(),
             )
+        } else if let Some(builtin) = next.maps_to_builtin() {
+            self.parser.parse_function_call(
+                lex,
+                |args| ExprNode::BuiltinCall(builtin, args),
+                lex.span(),
+            )
         } else if let Token::IndirectCall(name) = next {
             // Possible gawk bug: it accepts special variables if qualified,
             // even if it is with the `awk` namespace.

--- a/parser/src/sexpr.rs
+++ b/parser/src/sexpr.rs
@@ -292,7 +292,7 @@ impl Debug for Atom<'_> {
             Self::Variable(var) => write!(f, "{var:?}"),
             Self::String(str) => write!(f, "{str:?}"),
             Self::Number(num) => write!(f, "{num}"),
-            Self::SmallInt(num) => write!(f, "{num}"),
+            Self::Integer(num) => write!(f, "{num}"),
             Self::Regex(rgx) => write!(f, "/{rgx}/"),
             Self::TypedRegex(rgx) => write!(f, "@/{rgx}/"),
             Self::BigInt() | Self::BigFloat() => unimplemented!(),

--- a/parser/src/sexpr.rs
+++ b/parser/src/sexpr.rs
@@ -190,6 +190,13 @@ impl Debug for Expr<'_> {
                     }
                     write!(f, ")")
                 }
+                ExprNode::BuiltinCall(ident, args) => {
+                    write!(f, "({ident:?}")?;
+                    for arg in args {
+                        write!(f, " {arg:?}")?;
+                    }
+                    write!(f, ")")
+                }
                 ExprNode::UnaryOperation(op, a) => write!(f, "({op:?} {a:?})"),
                 ExprNode::BinaryOperation(op, a, b) => write!(f, "({op:?} {a:?} {b:?})"),
                 ExprNode::BinaryPlaceOperation(op, a, b) => write!(f, "({op:?} {a:?} {b:?})"),

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -732,7 +732,7 @@ fn test_parser_unary_and_divide() {
                     "(Divide awk::a awk::b) (Subtract (Add awk::a awk::b) awk::c))"
                 ))
             ),
-            (None, Some("(body (awk::int awk::a))")),
+            (None, Some("(body (Int awk::a))")),
         ],
     });
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,4 +2,5 @@ imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 max_width = 100
 struct_lit_width = 50
+struct_variant_width = 80
 newline_style = "Unix"


### PR DESCRIPTION
This is a very large, but necessary, change; I do not want to push it and create conflicts w/ everyone else's work. Ideally some other contributors can review it and get their work merged first.