### PR TITLE
lexer: encode \u escapes using locale encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +617,7 @@ name = "lexer"
 version = "0.1.0"
 dependencies = [
  "bumpalo",
+ "encoding_rs",
  "logos",
  "memchr",
  "thiserror",

--- a/lexer/Cargo.toml
+++ b/lexer/Cargo.toml
@@ -11,6 +11,7 @@ memchr.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 bumpalo.workspace = true
+encoding_rs = "0.8.35"
 
 [lints]
 workspace = true

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -6,6 +6,8 @@
 #[cfg(test)]
 mod tests;
 
+mod locale_encoding;
+
 use core::str;
 use std::{
     cmp::Ordering,
@@ -15,6 +17,7 @@ use std::{
 };
 
 use bumpalo::{Bump, collections::Vec};
+pub use locale_encoding::LocaleEncoding;
 use logos::{Logos, Skip};
 pub use logos::{Span, SpannedIter};
 use memchr::{memchr, memchr3};
@@ -314,6 +317,7 @@ pub struct Extra {
     arena: NonNull<Bump>,
     posix_strict: bool,
     gnu_strict: bool,
+    encoding: LocaleEncoding,
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -354,6 +358,22 @@ impl<'a> Token<'a> {
         posix_strict: bool,
         gnu_strict: bool,
     ) -> logos::Lexer<'a, Self> {
+        Self::lex_with_encoding(
+            source,
+            arena,
+            posix_strict,
+            gnu_strict,
+            LocaleEncoding::detect(),
+        )
+    }
+
+    pub fn lex_with_encoding(
+        source: &'a [u8],
+        arena: &'a Bump,
+        posix_strict: bool,
+        gnu_strict: bool,
+        encoding: LocaleEncoding,
+    ) -> logos::Lexer<'a, Self> {
         Lexer::with_extras(
             source,
             Extra {
@@ -361,6 +381,7 @@ impl<'a> Token<'a> {
                 arena: NonNull::from_ref(arena),
                 posix_strict,
                 gnu_strict,
+                encoding,
             },
         )
     }
@@ -445,6 +466,7 @@ fn parse_content<'a, const REGEX: bool, const DELIMITER: char>(
                     &rest[i..],
                     out.to_mut(lex.extras.arena()),
                     lex.extras.posix_strict,
+                    lex.extras.encoding,
                 )?;
                 start = i + consumed;
             }
@@ -462,6 +484,7 @@ fn parse_escape<const REGEX: bool>(
     slice: &[u8],
     out: &mut Vec<u8>,
     posix_strict: bool,
+    encoding: LocaleEncoding,
 ) -> Result<usize> {
     let mut count = 2;
     let is_oct = |x: char| ('0'..'8').contains(&x);
@@ -521,13 +544,7 @@ fn parse_escape<const REGEX: bool>(
                 count += num_digits;
 
                 let codepoint = parse_hex_digits(&slice[2..2 + num_digits]);
-
-                // FIXME: assumes UTF-8 locale; replacement character and encoding may differ
-                // for non-UTF-8 locales.
-                let c = char::from_u32(codepoint).unwrap_or('\u{FFFD}');
-                let mut buf = [0u8; 4];
-                let encoded = c.encode_utf8(&mut buf);
-                out.extend_from_slice_copy(encoded.as_bytes());
+                encoding.encode_unicode_escape(codepoint, out);
 
                 return Ok(count);
             }

--- a/lexer/src/locale_encoding.rs
+++ b/lexer/src/locale_encoding.rs
@@ -1,0 +1,109 @@
+// This file is part of the uutils awk package.
+//
+// For the full copyright and license information, please view the LICENSE
+// files that was distributed with this source code.
+
+//! Locale-aware encoding for `\u` escape sequences, matching gawk behavior.
+//!
+//! See: <https://www.gnu.org/software/gawk/manual/html_node/Escape-Sequences.html>
+
+use encoding_rs::{EncoderResult, Encoding, UTF_8};
+
+/// Character encoding derived from the process locale (`LC_*` / `LANG`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LocaleEncoding {
+    encoding: &'static Encoding,
+    /// `C` / `POSIX` locales only accept ASCII via `\u`.
+    ascii_only: bool,
+}
+
+impl LocaleEncoding {
+    pub fn utf8() -> Self {
+        Self { encoding: UTF_8, ascii_only: false }
+    }
+
+    /// `C` / `POSIX` locale: `\u` only encodes code points in ASCII.
+    pub fn ascii() -> Self {
+        Self { encoding: UTF_8, ascii_only: true }
+    }
+
+    /// ISO-8859-1 (Latin-1).
+    pub fn iso_8859_1() -> Self {
+        Self {
+            encoding: Encoding::for_label(b"iso-8859-1").unwrap_or(UTF_8),
+            ascii_only: false,
+        }
+    }
+
+    /// Detect encoding from `LC_ALL`, `LC_CTYPE`, or `LANG`.
+    pub fn detect() -> Self {
+        for var in ["LC_ALL", "LC_CTYPE", "LANG"] {
+            if let Some(os) = std::env::var_os(var)
+                && let Some(name) = os.to_str()
+            {
+                return Self::from_locale_name(name);
+            }
+        }
+        Self::from_locale_name("C.UTF-8")
+    }
+
+    /// Parse a locale name such as `en_US.UTF-8` or `C`.
+    pub fn from_locale_name(name: &str) -> Self {
+        let lower = name.to_ascii_lowercase();
+        let extension = lower.rsplit_once('.').map(|(_, ext)| ext);
+        let is_ascii = |c: &str| matches!(c, "c" | "posix");
+        if is_ascii(&lower) || extension.is_some_and(is_ascii) {
+            return Self::ascii();
+        }
+
+        let charset = name.rsplit('.').next().unwrap_or(name);
+        let label = charset.to_ascii_lowercase().replace('_', "-");
+
+        if label.contains("utf-8") || label == "utf8" {
+            return Self::utf8();
+        }
+
+        if let Some(encoding) = Encoding::for_label(label.as_bytes()) {
+            Self { encoding, ascii_only: false }
+        } else {
+            Self::utf8()
+        }
+    }
+
+    /// Encode a Unicode scalar value for a `\u` escape in the current locale.
+    ///
+    /// Invalid code points and characters that cannot be represented in the
+    /// locale encoding become `?`, matching gawk.
+    pub fn encode_unicode_escape(self, codepoint: u32, out: &mut impl Extend<u8>) {
+        let c = match char::try_from(codepoint) {
+            Ok(c) if !self.ascii_only || c.is_ascii() => c,
+            _ => {
+                out.extend([b'?']);
+                return;
+            }
+        };
+
+        if self.encoding == UTF_8 && !self.ascii_only {
+            let mut buf = [0u8; 4];
+            out.extend(c.encode_utf8(&mut buf).bytes());
+            return;
+        }
+
+        let mut encoder = self.encoding.new_encoder();
+        let mut buf = [0u8; 8];
+        let mut utf8 = [0u8; 4];
+        let ch = c.encode_utf8(&mut utf8);
+        match encoder.encode_from_utf8_without_replacement(ch, &mut buf, true) {
+            (EncoderResult::InputEmpty, _, written) if written > 0 => {
+                out.extend(buf[..written].iter().copied());
+            }
+            _ => out.extend([b'?']),
+        }
+    }
+}
+
+impl Default for LocaleEncoding {
+    fn default() -> Self {
+        Self::utf8()
+    }
+}

--- a/lexer/src/tests.rs
+++ b/lexer/src/tests.rs
@@ -10,7 +10,7 @@ use bumpalo::{
     collections::{CollectIn, Vec},
 };
 
-use crate::{Identifier, Token};
+use crate::{Identifier, LocaleEncoding, Token};
 
 fn lex<'a>(
     src: &'a [u8],
@@ -18,7 +18,17 @@ fn lex<'a>(
     posix_strict: bool,
     gnu_strict: bool,
 ) -> Vec<'a, Token<'a>> {
-    Token::lex(src, arena, posix_strict, gnu_strict)
+    lex_with_encoding(src, arena, posix_strict, gnu_strict, LocaleEncoding::utf8())
+}
+
+fn lex_with_encoding<'a>(
+    src: &'a [u8],
+    arena: &'a Bump,
+    posix_strict: bool,
+    gnu_strict: bool,
+    encoding: LocaleEncoding,
+) -> Vec<'a, Token<'a>> {
+    Token::lex_with_encoding(src, arena, posix_strict, gnu_strict, encoding)
         .collect_in::<Result<Vec<_>, _>>(arena)
         .unwrap()
 }
@@ -357,6 +367,105 @@ fn lexer_test_unicode_escape_eight_digits() {
     assert_eq!(
         &lex(b"\"\\u00000032\"", &arena, false, false),
         &[Token::String(b"2".into())]
+    );
+}
+
+#[test]
+fn lexer_test_unicode_escape_iso8859_1() {
+    let arena = Bump::new();
+    assert_eq!(
+        &lex_with_encoding(
+            b"\"\\u00e9\"",
+            &arena,
+            false,
+            false,
+            LocaleEncoding::iso_8859_1()
+        ),
+        &[Token::String(b"\xe9".into())]
+    );
+    assert_eq!(
+        &lex_with_encoding(
+            b"\"\\u0041\"",
+            &arena,
+            false,
+            false,
+            LocaleEncoding::iso_8859_1()
+        ),
+        &[Token::String(b"A".into())]
+    );
+    assert_eq!(
+        &lex_with_encoding(
+            b"\"\\u4e2d\"",
+            &arena,
+            false,
+            false,
+            LocaleEncoding::iso_8859_1()
+        ),
+        &[Token::String(b"?".into())]
+    );
+}
+
+#[test]
+fn lexer_test_unicode_escape_ascii_locale() {
+    let arena = Bump::new();
+    assert_eq!(
+        &lex_with_encoding(
+            b"\"\\u0041\"",
+            &arena,
+            false,
+            false,
+            LocaleEncoding::ascii()
+        ),
+        &[Token::String(b"A".into())]
+    );
+    assert_eq!(
+        &lex_with_encoding(
+            b"\"\\u00e9\"",
+            &arena,
+            false,
+            false,
+            LocaleEncoding::ascii()
+        ),
+        &[Token::String(b"?".into())]
+    );
+}
+
+#[test]
+fn lexer_test_unicode_escape_invalid_codepoint() {
+    let arena = Bump::new();
+    assert_eq!(
+        &lex_with_encoding(
+            b"\"\\u110000\"",
+            &arena,
+            false,
+            false,
+            LocaleEncoding::utf8()
+        ),
+        &[Token::String(b"?".into())]
+    );
+    assert_eq!(
+        &lex_with_encoding(b"\"\\uD800\"", &arena, false, false, LocaleEncoding::utf8()),
+        &[Token::String(b"?".into())]
+    );
+}
+
+#[test]
+fn locale_encoding_from_locale_name() {
+    assert_eq!(
+        LocaleEncoding::from_locale_name("C"),
+        LocaleEncoding::ascii()
+    );
+    assert_eq!(
+        LocaleEncoding::from_locale_name("POSIX"),
+        LocaleEncoding::ascii()
+    );
+    assert_eq!(
+        LocaleEncoding::from_locale_name("en_US.UTF-8"),
+        LocaleEncoding::utf8()
+    );
+    assert_eq!(
+        LocaleEncoding::from_locale_name("fr_FR.ISO-8859-1"),
+        LocaleEncoding::iso_8859_1()
     );
 }
 


### PR DESCRIPTION
Detect charset from LC_ALL/LC_CTYPE/LANG and encode \u sequences into the locale multibyte encoding (UTF-8, ISO-8859-1, ASCII-only for C/POSIX), matching gawk. Unrepresentable or invalid code points become '?'.

Closes: #40