### PR TITLE
parser: enforce statement end after commands

### DIFF
--- a/parser/src/lex.rs
+++ b/parser/src/lex.rs
@@ -212,7 +212,6 @@ pub trait TokenExt {
     fn maps_to_special_pat(&self) -> Option<SpecialPattern>;
     fn is_stmnt_end(&self) -> bool;
     fn is_stmnt_or_block_end(&self) -> bool;
-    fn is_brace(&self) -> bool;
 }
 
 impl TokenExt for Token<'_> {
@@ -333,9 +332,6 @@ impl TokenExt for Token<'_> {
     }
     fn is_stmnt_or_block_end(&self) -> bool {
         self.is_stmnt_end() || self == &Token::ClosedBrace
-    }
-    fn is_brace(&self) -> bool {
-        matches!(self, Token::OpenBrace | Token::ClosedBrace)
     }
 }
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -190,27 +190,42 @@ impl<'a> Parser<'a> {
         lex.expect(&Token::OpenBrace, ParsingError::ExpectedOpeningBrace)?;
         let mut body = Vec::new_in(self.arena);
         let mut depth = 0;
+        let mut after_separator = true;
 
         loop {
-            if lex.peek_with(|tok| tok.is_stmnt_end() || tok.is_brace()) {
-                match lex.expect_next()? {
-                    Token::ClosedBrace => {
-                        if depth == 0 {
-                            break Ok(Body(body));
-                        }
-                        depth -= 1;
-                    }
-                    Token::OpenBrace => {
-                        depth += 1;
-                    }
-                    _ => {}
+            let stmnt_end = lex.consume_with(Token::is_stmnt_end);
+            if stmnt_end {
+                after_separator = true;
+            }
+
+            match lex.peek() {
+                Some(Ok(Token::ClosedBrace)) if depth == 0 && !stmnt_end => {
+                    lex.next();
+                    break Ok(Body(body));
                 }
-            } else if lex.peek().is_some() {
-                body.push(self.parse_statement(lex)?);
-            } else {
-                break Err(ParsingError::UnclosedScope(
-                    lex.peeked_span().unwrap_or_else(|_| lex.span()),
-                ));
+                Some(Ok(Token::ClosedBrace)) => {
+                    depth -= 1;
+                    lex.next();
+                    after_separator = true;
+                }
+                Some(Ok(Token::OpenBrace)) if after_separator || depth > 0 => {
+                    depth += 1;
+                    lex.next();
+                    after_separator = false;
+                }
+                Some(Ok(Token::OpenBrace)) => {
+                    break Err(ParsingError::ExpectedStatementEnd(lex.span()));
+                }
+                Some(_) => {
+                    let (statement, consumed) = self.parse_statement_with_trailing(lex)?;
+                    body.push(statement);
+                    after_separator = consumed;
+                }
+                None => {
+                    break Err(ParsingError::UnclosedScope(
+                        lex.peeked_span().unwrap_or_else(|_| lex.span()),
+                    ));
+                }
             }
         }
     }
@@ -248,6 +263,15 @@ impl<'a> Parser<'a> {
 
     #[tracing::instrument]
     fn parse_statement(&mut self, lex: &mut Lexer<'a>) -> Result<Statement<'a>> {
+        self.parse_statement_with_trailing(lex)
+            .map(|(statement, _)| statement)
+    }
+
+    #[tracing::instrument]
+    fn parse_statement_with_trailing(
+        &mut self,
+        lex: &mut Lexer<'a>,
+    ) -> Result<(Statement<'a>, bool)> {
         let statement = if let Some(statement) = self.parse_simple_statement(lex) {
             Statement::Simple(statement?)
         } else {
@@ -372,8 +396,8 @@ impl<'a> Parser<'a> {
             }
         };
 
-        lex.consume_with(Token::is_stmnt_end);
-        Ok(statement)
+        let consumed = lex.consume_with(Token::is_stmnt_end);
+        Ok((statement, consumed))
     }
 
     #[tracing::instrument]

--- a/parser/src/tests.rs
+++ b/parser/src/tests.rs
@@ -196,6 +196,18 @@ fn test_parser_invalid_patterns() {
 }
 
 #[test]
+fn test_parser_statement_end_after_command() {
+    test_parser!(is_err!(
+        "{ print 1 { 1 + 1 } }",
+        "{ print 1 { } }",
+        "{ printf \"%d\" 1 { } }"
+    ));
+    test_parser!("{ print 1; { print 2 } }" => {
+        rules: [(None, Some("(body (Print 1) (Print 2))"))],
+    });
+}
+
+#[test]
 fn test_parser_reserved_qualified_identifiers() {
     test_parser!(is_err!(
         "{ if::while }",


### PR DESCRIPTION
Reject bare `{` after commands instead of treating it as nested brace depth.

Fixes #36