### PR TITLE
clippy: fix warnings

### DIFF
--- a/lexer/src/locale_encoding.rs
+++ b/lexer/src/locale_encoding.rs
@@ -78,7 +78,7 @@ impl LocaleEncoding {
         let c = match char::try_from(codepoint) {
             Ok(c) if !self.ascii_only || c.is_ascii() => c,
             _ => {
-                out.extend([b'?']);
+                out.extend(*b"?");
                 return;
             }
         };
@@ -97,7 +97,7 @@ impl LocaleEncoding {
             (EncoderResult::InputEmpty, _, written) if written > 0 => {
                 out.extend(buf[..written].iter().copied());
             }
-            _ => out.extend([b'?']),
+            _ => out.extend(*b"?"),
         }
     }
 }

--- a/parser/src/tests/ast_gen.rs
+++ b/parser/src/tests/ast_gen.rs
@@ -311,6 +311,6 @@ fn text_slice<'a>(arena: &'a Bump, content: &str) -> lexer::Slice<'a> {
     arena.alloc_str(content).as_bytes().into()
 }
 
-fn regex_slice<'a>(arena: &'a Bump, index: u8) -> lexer::Slice<'a> {
+fn regex_slice(arena: &Bump, index: u8) -> lexer::Slice<'_> {
     text_slice(arena, &format!("p{index}"))
 }

--- a/parser/src/tests/ast_gen.rs
+++ b/parser/src/tests/ast_gen.rs
@@ -51,10 +51,10 @@ pub enum GenStatement {
 #[derive(Clone, Debug)]
 pub enum GenExpr {
     Atom(GenAtom),
-    Unary(UnaryOperator, Box<GenExpr>),
-    Binary(BinaryOperator, Box<GenExpr>, Box<GenExpr>),
-    Assign(GenPlace, Box<GenExpr>),
-    Index(u8, Box<GenExpr>),
+    Unary(UnaryOperator, Box<Self>),
+    Binary(BinaryOperator, Box<Self>, Box<Self>),
+    Assign(GenPlace, Box<Self>),
+    Index(u8, Box<Self>),
 }
 
 #[derive(Clone, Debug)]

--- a/parser/src/tests/utils.rs
+++ b/parser/src/tests/utils.rs
@@ -152,7 +152,7 @@ pub fn ast_signature(ast: &Ast<'_>) -> String {
     for body in &ast.end {
         let _ = writeln!(out, "end:{body:?}");
     }
-    for (name, fun) in ast.functions.iter() {
+    for (name, fun) in &ast.functions {
         let _ = writeln!(out, "function:{name:?}:{fun:?}");
     }
     out


### PR DESCRIPTION
This PR fixes warnings from the [explicit_iter_loop](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop), [elidable_lifetime_names](https://rust-lang.github.io/rust-clippy/master/index.html#elidable_lifetime_names), [use_self](https://rust-lang.github.io/rust-clippy/master/index.html#use_self), and [byte_char_slices](https://rust-lang.github.io/rust-clippy/master/index.html#byte_char_slices) lints.