### PR TITLE
Interpreter: switch statement lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "indexmap-allocator-api",
  "memchr",
  "parser",
+ "regex",
  "thiserror",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ allocator-api2 = "0.4.0"
 ahash = "0.8.12"
 derive_more = { version = "2.1.1", features = ["from", "debug", "display"] }
 
+regex = "1.12.3"
+
 [dependencies]
 interpreter.workspace = true
 parser.workspace = true

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -15,6 +15,7 @@ bumpalo.workspace = true
 allocator-api2.workspace = true
 hashbrown.workspace = true
 ahash.workspace = true
+regex.workspace = true
 # I'm not particularly happy about this, but it's crucial for performance, and
 # I have audited the two commits. It's pinned to that hash to avoid possible
 # supply-chain attacks. Hopefully upstream maintainers will change their mind.

--- a/interpreter/src/ir.rs
+++ b/interpreter/src/ir.rs
@@ -111,6 +111,14 @@ impl Instruction {
         }
     }
 
+    fn set_then_label(&mut self, label: Label) {
+        if let Self::Branch { then_label, else_label: _, condition: _ } = self {
+            *then_label = label;
+        } else {
+            debug_assert!(false, "Incorrect label set!");
+        }
+    }
+
     fn push_end_label(&mut self) {
         if let Self::Branch { else_label, then_label: _, condition: _ } = self {
             else_label.0 += 1;

--- a/interpreter/src/ir/lower.rs
+++ b/interpreter/src/ir/lower.rs
@@ -185,8 +185,95 @@ impl<'a> CodeGen<'a> {
                 self.bc
                     .emit(Instruction::OutputCall { start, end, cmd: *name, redir });
             }
+            Statement::Switch { scrutinee, branches, default } => {
+                self.lower_switch(scrutinee, branches, default.as_ref());
+            }
             _ => todo!(),
         }
+    }
+
+    fn lower_switch(
+        &mut self,
+        scrutinee: &Expr<'_>,
+        branches: &[(Atom<'_>, Body<'_>)],
+        default: Option<&(Body<'_>, usize)>,
+    ) {
+        let scr = self.alloc_reg();
+        self.lower_expr_into(scrutinee, *scr);
+        let cmp = self.alloc_reg();
+
+        let default_pos = default.map_or(branches.len(), |(_, pos)| *pos);
+        let mut pending_branches = Vec::new_in(self.arena);
+        for (i, (atom, _)) in branches.iter().enumerate() {
+            pending_branches.push(self.emit_switch_case_match(*scr, *cmp, atom, i));
+        }
+        let no_match_jump = self.bc.emit(Instruction::Jump { to: Label(0) });
+
+        let mut case_labels = Vec::with_capacity_in(branches.len(), self.arena);
+        case_labels.resize(branches.len(), Label(0));
+
+        for (i, (_, body)) in branches.iter().enumerate().take(default_pos) {
+            case_labels[i] = Label(self.bc.len());
+            self.lower_body(body);
+        }
+
+        let default_label = if let Some((body, _)) = default {
+            let label = Label(self.bc.len());
+            self.lower_body(body);
+            Some(label)
+        } else {
+            None
+        };
+
+        for (i, (_, body)) in branches.iter().enumerate().skip(default_pos) {
+            case_labels[i] = Label(self.bc.len());
+            self.lower_body(body);
+        }
+
+        let end_switch = self.following_instr(0);
+
+        for (br_label, case_ix) in pending_branches {
+            self.bc.nth(br_label).set_then_label(case_labels[case_ix]);
+        }
+
+        let no_match_target = default_label.unwrap_or(end_switch);
+        self.bc.nth(no_match_jump).set_label(no_match_target);
+        self.free_reg(cmp);
+        self.free_reg(scr);
+    }
+
+    fn emit_switch_case_match(
+        &mut self,
+        scr: Reg,
+        cmp: Reg,
+        case: &Atom<'_>,
+        case_ix: usize,
+    ) -> (Label, usize) {
+        let lhs = TypedArg::from(scr);
+        let tyl = ArgTy::Reg;
+
+        match case {
+            Atom::Regex(r) | Atom::TypedRegex(r) => {
+                let buf = &*self.arena.alloc_slice_copy(r.as_ref());
+                let TypedArg(rhs, tyr) = TypedArg::new_cnt(self, Value::Regex(buf.into()));
+                self.bc
+                    .emit(Instruction::Matches { dest: cmp, lhs: lhs.0, rhs, tyl, tyr });
+            }
+            atom => {
+                let case_val = self.lower_atom(atom);
+                let TypedArg(rhs, tyr) = case_val.to_arg();
+                self.bc
+                    .emit(Instruction::Eq { dest: cmp, lhs: lhs.0, rhs, tyl, tyr });
+                case_val.free(self);
+            }
+        }
+
+        let br_label = self.bc.emit(Instruction::Branch {
+            condition: cmp,
+            then_label: Label(0),
+            else_label: self.following_instr(1),
+        });
+        (br_label, case_ix)
     }
 
     fn lower_expr(&mut self, expr: &Expr) -> Operand {
@@ -711,5 +798,120 @@ impl From<&LinearReg> for Reg {
 impl From<&Self> for Reg {
     fn from(value: &Self) -> Self {
         *value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bumpalo::Bump;
+    use parser::Parser;
+
+    fn with_lower(source: &str, f: impl FnOnce(&CodeGen<'_>)) {
+        let arena = Bump::new();
+        let mut parser = Parser::new(&arena, false);
+        let ast = parser.parse("test", source.as_bytes()).expect("parse");
+        let mut cg = CodeGen::new(&arena);
+        cg.lower_ast(ast);
+        f(&cg);
+    }
+
+    #[test]
+    fn switch_lowers_case_comparisons() {
+        with_lower(
+            "BEGIN { switch (x) { case 1: print; case \"a\": print 2; default: print 3 } }",
+            |cg| {
+                let bc = format!("{}", cg.bc);
+                assert!(
+                    bc.contains(" <- eq "),
+                    "expected Eq for literal cases:\n{bc}"
+                );
+                assert!(bc.contains("brif"), "expected case branches:\n{bc}");
+                assert!(bc.contains("jmp"), "expected jumps to end of switch:\n{bc}");
+            },
+        );
+    }
+
+    #[test]
+    fn switch_lowers_regex_case_with_matches() {
+        with_lower("BEGIN { switch (x) { case /pat/: print } }", |cg| {
+            let bc = format!("{}", cg.bc);
+            assert!(
+                bc.contains(" <- mtch "),
+                "expected Matches for regex case:\n{bc}"
+            );
+            assert!(
+                !bc.contains(" <- eq "),
+                "regex case should not use Eq:\n{bc}"
+            );
+        });
+    }
+
+    #[test]
+    fn switch_default_in_middle_uses_no_match_jump_only() {
+        with_lower(
+            "BEGIN { switch (x) { case 1: print 1; default: print 2; case 3: print 3 } }",
+            |cg| {
+                let jmp_count = cg
+                    .bc
+                    .code
+                    .iter()
+                    .filter(|i| matches!(i, Instruction::Jump { .. }))
+                    .count();
+                assert_eq!(
+                    jmp_count, 1,
+                    "expected a single no-match jump, not per-case exits:\n{}",
+                    cg.bc
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn switch_typed_regex_case_uses_matches() {
+        with_lower("BEGIN { switch (x) { case @/pat/: print } }", |cg| {
+            let bc = format!("{}", cg.bc);
+            assert!(
+                bc.contains(" <- mtch "),
+                "expected Matches for typed regex case:\n{bc}"
+            );
+        });
+    }
+
+    #[test]
+    fn switch_no_exit_jumps_between_case_bodies() {
+        with_lower(
+            "BEGIN { switch (1) { case 1: print; default: print 2 } }",
+            |cg| {
+                let jmp_count = cg
+                    .bc
+                    .code
+                    .iter()
+                    .filter(|i| matches!(i, Instruction::Jump { .. }))
+                    .count();
+                assert_eq!(
+                    jmp_count, 1,
+                    "gawk switch fallthrough should not emit per-case exit jumps:\n{}",
+                    cg.bc
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn switch_scrutinee_expression_is_evaluated_once() {
+        with_lower("BEGIN { switch (1 + 1) { case 2: print } }", |cg| {
+            let add_count = cg
+                .bc
+                .code
+                .iter()
+                .filter(|i| matches!(i, Instruction::Add { .. }))
+                .count();
+            assert_eq!(
+                add_count, 1,
+                "scrutinee should be evaluated once:\n{}",
+                cg.bc
+            );
+        });
     }
 }

--- a/interpreter/src/types.rs
+++ b/interpreter/src/types.rs
@@ -77,6 +77,22 @@ impl Value<'_> {
         Self::Float(b as usize as f64)
     }
 
+    // FIXME: gawk supports regex extensions beyond the `regex` crate; compile patterns
+    // once and route matching through a dedicated layer (likely regex-automata).
+    pub(crate) fn matches_regex(&self, pattern: &[u8]) -> bool {
+        let mut subject = Vec::with_capacity(self.string_size_hint());
+        self.write_string(&mut subject);
+        let Ok(subject) = str::from_utf8(&subject) else {
+            return false;
+        };
+        let Ok(pattern) = str::from_utf8(pattern) else {
+            return false;
+        };
+        regex::Regex::new(pattern)
+            .ok()
+            .is_some_and(|re| re.is_match(subject))
+    }
+
     pub fn write_string(&self, f: &mut Vec<u8>) {
         match self {
             Self::String(s) | Self::Regex(s) => f.extend_from_slice(s),

--- a/interpreter/src/vm.rs
+++ b/interpreter/src/vm.rs
@@ -195,8 +195,22 @@ impl Interpreter<'_> {
                 }
                 Instruction::And { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
                 Instruction::Or { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
-                Instruction::Matches { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
-                Instruction::MatchesNot { dest: _, lhs: _, rhs: _, tyr: _, tyl: _ } => todo!(),
+                Instruction::Matches { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, lhs: tyl, rhs: tyr);
+                    let matched = match rhs {
+                        Value::Regex(pat) => lhs.matches_regex(pat),
+                        _ => false,
+                    };
+                    self.registers.write(dest, Value::b2f(matched));
+                }
+                Instruction::MatchesNot { dest, lhs, rhs, tyl, tyr } => {
+                    rx!(self, lhs: tyl, rhs: tyr);
+                    let matched = match rhs {
+                        Value::Regex(pat) => lhs.matches_regex(pat),
+                        _ => false,
+                    };
+                    self.registers.write(dest, Value::b2f(!matched));
+                }
                 Instruction::Add { dest, lhs, rhs, tyl, tyr } => {
                     rx!(self, dest, lhs: tyl, rhs: tyr, lhs + rhs);
                 }

--- a/tests/by-util/test_awk.rs
+++ b/tests/by-util/test_awk.rs
@@ -20,6 +20,70 @@ fn no_args_fails_code_one() {
     ucmd().fails_with_code(1);
 }
 
+#[test]
+fn switch_default_in_middle_fallthrough() {
+    ucmd()
+        .arg("BEGIN { x = 1; switch (x) { case 1: print 1; default: print 2; case 3: print 3 } }")
+        .succeeds()
+        .stdout_only("1\n2\n3\n");
+    ucmd()
+        .arg("BEGIN { x = 2; switch (x) { case 1: print 1; default: print 2; case 3: print 3 } }")
+        .succeeds()
+        .stdout_only("2\n3\n");
+}
+
+#[test]
+fn switch_matches_integer_case_with_fallthrough() {
+    ucmd()
+        .arg("BEGIN { x = 1; switch (x) { case 1: print \"one\"; default: print \"def\" } }")
+        .succeeds()
+        .stdout_only("one\ndef\n");
+}
+
+#[test]
+fn switch_falls_through_to_default() {
+    ucmd()
+        .arg("BEGIN { x = 9; switch (x) { case 1: print 1; default: print 2 } }")
+        .succeeds()
+        .stdout_only("2\n");
+}
+
+#[test]
+fn switch_default_first_still_tests_later_cases() {
+    ucmd()
+        .arg("BEGIN { x = 3; switch (x) { default: print 2; case 3: print 3 } }")
+        .succeeds()
+        .stdout_only("3\n");
+    ucmd()
+        .arg("BEGIN { x = 4; switch (x) { default: print 2; case 3: print 3 } }")
+        .succeeds()
+        .stdout_only("2\n3\n");
+}
+
+#[test]
+fn switch_string_case_match_with_fallthrough() {
+    ucmd()
+        .arg("BEGIN { x = \"a\"; switch (x) { case \"a\": print \"match\"; default: print \"no\" } }")
+        .succeeds()
+        .stdout_only("match\nno\n");
+}
+
+#[test]
+fn switch_regex_case_match() {
+    ucmd()
+        .arg("BEGIN { x = \"abc\"; switch (x) { case /bc/: print \"match\" } }")
+        .succeeds()
+        .stdout_only("match\n");
+}
+
+#[test]
+fn switch_no_match_without_default_continues() {
+    ucmd()
+        .arg("BEGIN { x = 2; switch (x) { case 1: print 1 }; print \"done\" }")
+        .succeeds()
+        .stdout_only("done\n");
+}
+
 // Regression test for issue #5: writing to /dev/full must not panic.
 #[cfg(target_os = "linux")]
 #[test]


### PR DESCRIPTION
Add AST lowering for switch: evaluate the scrutinee once into a register, emit a branch chain for each case, and jump to the default branch or past the statement when nothing matches.

Match literal cases with Eq; match regex and typed-regex cases with Matches. Support default placed anywhere in the case list, including before later cases.

Fixes #70