### PR TITLE
interpreter: arrays

### DIFF
--- a/interpreter/src/ir/lower.rs
+++ b/interpreter/src/ir/lower.rs
@@ -9,8 +9,8 @@ use bumpalo::{Bump, collections::Vec};
 use either::Either;
 use indexmap_allocator_api::IndexSet;
 use parser::{
-    Ast, Atom, BinaryOperator, BinaryPlaceOperator, Body, Command, Expr, ExprNode, Identifier,
-    MetaId, Place, Rule, RulePattern, SimpleStatement, Statement, UnaryOperator,
+    ArrayOperator, Ast, Atom, BinaryOperator, BinaryPlaceOperator, Body, Command, Expr, ExprNode,
+    Identifier, MetaId, Place, Rule, RulePattern, SimpleStatement, Statement, UnaryOperator,
     UnaryPlaceOperator, Variable,
 };
 
@@ -579,6 +579,9 @@ impl<'a> CodeGen<'a> {
                             }
                         }
                         ExprNode::Parenthesized(expr) => this.lower_expr_into(expr, dest),
+                        ExprNode::ArrayOperation(ArrayOperator::Index, var, index) => {
+                            this.load_index(dest, var, index);
+                        }
                         _ => todo!(),
                     }
                 });
@@ -593,20 +596,23 @@ impl<'a> CodeGen<'a> {
             }
             Place::Variable(Variable::User(ident)) => TypedArg::new_us(self, ident),
             Place::Variable(var) => TypedArg::new_is(var),
-            Place::Index(Variable::User(ident), index) => {
-                let var = self.symbols.register_user_var(ident, self.arena);
-                let (start, end, _) = self.gen_call_convention(index, |_| ());
-                self.emit(Instruction::LoadA { dest, ty_place: ArgTy::UaVal, start, end, var });
-                TypedArg(Arg { sym: var }, ArgTy::UaVal)
-            }
-            Place::Index(var, index) => {
-                let (start, end, _) = self.gen_call_convention(index, |_| ());
-                let var = var_index(var);
-                self.emit(Instruction::LoadA { dest, ty_place: ArgTy::UaVal, start, end, var });
-                TypedArg(Arg { sym: var }, ArgTy::IaVal)
-            }
+            Place::Index(var, index) => self.load_index(dest, var, index),
             Place::ChainedIndex(_, _) => todo!(),
         }
+    }
+
+    fn load_index(&mut self, dest: Reg, var: &Variable<'_>, index: &[Expr<'_>]) -> TypedArg {
+        if let Variable::User(ident) = var {
+            let var = self.symbols.register_user_var(ident, self.arena);
+            let (start, end, _) = self.gen_call_convention(index, |_| ());
+            self.emit(Instruction::LoadA { dest, ty_place: ArgTy::UaVal, start, end, var });
+        } else {
+            let (start, end, _) = self.gen_call_convention(index, |_| ());
+            let var = var_index(var);
+            self.emit(Instruction::LoadA { dest, ty_place: ArgTy::IaVal, start, end, var });
+        }
+        // Element value was written to `dest`; subsequent ops must use the register.
+        dest.into()
     }
 
     fn store_place(&mut self, place: &Place<'_>, dest: Reg, src: TypedArg) {
@@ -1356,5 +1362,40 @@ mod tests {
                 );
             },
         );
+    }
+
+    #[test]
+    fn array_index_assignment_lowers_storea() {
+        with_lower("BEGIN { a[1] = 2 }", |cg| {
+            let bc = format!("{}", cg.bc);
+            assert!(bc.contains("astore"), "expected StoreA:\n{bc}");
+            assert!(bc.contains("ua("), "expected user-array place:\n{bc}");
+        });
+    }
+
+    #[test]
+    fn array_index_read_lowers_loada() {
+        with_lower("BEGIN { print a[1] }", |cg| {
+            let bc = format!("{}", cg.bc);
+            assert!(bc.contains("aload"), "expected LoadA:\n{bc}");
+            assert!(bc.contains("ua("), "expected user-array place:\n{bc}");
+        });
+    }
+
+    #[test]
+    fn array_index_increment_lowers_load_and_store() {
+        with_lower("BEGIN { ++a[1] }", |cg| {
+            let bc = format!("{}", cg.bc);
+            assert!(bc.contains("aload"), "expected LoadA:\n{bc}");
+            assert!(bc.contains("astore"), "expected StoreA:\n{bc}");
+        });
+    }
+
+    #[test]
+    fn array_multi_index_assignment_lowers_storea() {
+        with_lower("BEGIN { a[1, 2] = 3 }", |cg| {
+            let bc = format!("{}", cg.bc);
+            assert!(bc.contains("astore"), "expected StoreA:\n{bc}");
+        });
     }
 }

--- a/interpreter/src/types.rs
+++ b/interpreter/src/types.rs
@@ -5,15 +5,21 @@
 
 use std::{
     borrow::Cow,
+    cell::RefCell,
     fmt::Display,
     hash::Hash,
     io::Write,
     mem::discriminant,
     ops::{Add, BitXor, Div, Mul, Rem, Sub},
+    rc::Rc,
 };
 
 use ahash::RandomState;
 use hashbrown::HashMap;
+
+/// Shared array storage. AWK arrays are reference-counted (assignment of array
+/// names is not a deep copy); `Rc`/`RefCell` is enough while the VM is single-threaded.
+pub type ArrayMap<'a> = HashMap<String, Value<'a>, RandomState>;
 
 #[derive(Debug, Clone)]
 pub enum Value<'a> {
@@ -21,10 +27,18 @@ pub enum Value<'a> {
     Float(f64),
     String(Cow<'a, [u8]>),
     Regex(Cow<'a, [u8]>),
-    Array(HashMap<String, Self, RandomState>),
+    Array(Rc<RefCell<ArrayMap<'a>>>),
     Bool(bool),
     Untyped,
     Unassigned,
+}
+
+impl Value<'_> {
+    pub fn empty_array() -> Self {
+        Self::Array(Rc::new(RefCell::new(HashMap::with_hasher(
+            RandomState::new(),
+        ))))
+    }
 }
 
 impl Value<'_> {
@@ -41,9 +55,9 @@ impl Value<'_> {
     }
 
     pub fn array_context(&mut self) -> &mut Self {
-        // TODO: Exit "nicely" on Self::Array(_).
+        // TODO: Exit "nicely" on non-array scalars.
         match self {
-            Self::Untyped => *self = Self::Array(HashMap::with_hasher(RandomState::new())),
+            Self::Untyped => *self = Self::empty_array(),
             Self::Array(_) => {}
             _ => panic!("Attempted to use scalar as array!"),
         }
@@ -297,6 +311,24 @@ impl Display for Value<'_> {
             Value::Regex(s) => write!(f, "/{}/", String::from_utf8_lossy(s)),
             &Value::Bool(b) => write!(f, "{}", b as usize),
             Value::Array(_) | Value::Untyped | Value::Unassigned => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn array_clone_shares_backing_storage() {
+        let a = Value::empty_array();
+        let b = a.clone();
+        match (&a, &b) {
+            (Value::Array(left), Value::Array(right)) => {
+                left.borrow_mut().insert("k".into(), Value::Int(1));
+                assert_eq!(right.borrow().get("k"), Some(&Value::Int(1)));
+            }
+            _ => panic!("expected Array values"),
         }
     }
 }

--- a/interpreter/src/vm.rs
+++ b/interpreter/src/vm.rs
@@ -4,10 +4,12 @@
 // files that was distributed with this source code.
 
 use std::{
+    cell::RefCell,
     fmt::{self, Display},
     io::{self, Write},
     mem::replace,
     ops::Range,
+    rc::Rc,
     vec::Vec as StdVec,
 };
 
@@ -19,10 +21,10 @@ use parser::{Command, Identifier, Redirection};
 
 use crate::{
     ir::{
-        Instruction, IxWidth, Label, NonLocal, Reg,
+        ArgTy, Instruction, IxWidth, Label, NonLocal, Reg,
         lower::{Bytecode, CodeGen},
     },
-    types::Value,
+    types::{ArrayMap, Value},
 };
 
 #[derive(Debug)]
@@ -75,6 +77,8 @@ pub struct SymbolTable<'a> {
     records: HashMap<usize, Value<'a>, RandomState, &'a Bump>,
     ofs: Value<'a>,
     rfs: Value<'a>,
+    /// Default AWK `SUBSEP` (`"\034"`).
+    subsep: Value<'a>,
     // etc
 }
 
@@ -105,6 +109,7 @@ impl<'a> SymbolTable<'a> {
             records: HashMap::with_hasher_in(RandomState::new(), arena),
             ofs: Value::String(b" ".into()),
             rfs: Value::String(b"\n".into()),
+            subsep: Value::String(b"\x1c".into()),
         }
     }
 
@@ -115,6 +120,27 @@ impl<'a> SymbolTable<'a> {
 
     fn write_user_val(&mut self, var: NonLocal, value: Value<'a>) {
         *self.user.get_index_mut(var.0 as _).unwrap().1 = value;
+    }
+
+    fn user_array(&mut self, var: NonLocal) -> Rc<RefCell<ArrayMap<'a>>> {
+        let v = self.user.get_index_mut(var.0 as _).unwrap().1;
+        v.array_context();
+        match v {
+            Value::Array(arr) => Rc::clone(arr),
+            _ => unreachable!("array_context must leave an Array"),
+        }
+    }
+
+    fn load_user_array_elem(&mut self, var: NonLocal, key: &str) -> Value<'a> {
+        self.user_array(var)
+            .borrow()
+            .get(key)
+            .cloned()
+            .unwrap_or(Value::Unassigned)
+    }
+
+    fn store_user_array_elem(&mut self, var: NonLocal, key: String, value: Value<'a>) {
+        self.user_array(var).borrow_mut().insert(key, value);
     }
 
     pub fn register_user_var(&mut self, var: &Identifier, bump: &'a Bump) -> NonLocal {
@@ -268,7 +294,15 @@ impl Interpreter<'_> {
                     rhs.write_string(&mut buf);
                     self.registers.write(dest, Value::String(buf.into()));
                 }
-                Instruction::LoadA { dest: _, ty_place: _, start: _, end: _, var: _ } => todo!(),
+                Instruction::LoadA { dest, ty_place, start, end, var } => {
+                    let key = self.make_array_key(start, end);
+                    let value = match ty_place {
+                        ArgTy::UaVal => self.symbols.load_user_array_elem(var, &key),
+                        ArgTy::IaVal => todo!("intrinsic array load"),
+                        _ => unreachable!(),
+                    };
+                    self.registers.write(dest, value);
+                }
                 Instruction::StoreS { dest, ty_place, var, arg, ty } => {
                     rx!(self, arg: ty);
                     match ty_place {
@@ -281,14 +315,18 @@ impl Interpreter<'_> {
                 Instruction::StoreR { dest: _, src: _, arg: _, ty: _, tys: _ } => {
                     todo!()
                 }
-                Instruction::StoreA {
-                    dest: _,
-                    ty_place: _,
-                    start: _,
-                    end: _,
-                    var: _,
-                    arg: _,
-                } => todo!(),
+                Instruction::StoreA { dest, ty_place, start, end, var, arg } => {
+                    let key = self.make_array_key(start, end);
+                    let value = self.registers.get(arg).clone();
+                    match ty_place {
+                        ArgTy::UaVal => {
+                            self.symbols.store_user_array_elem(var, key, value.clone());
+                        }
+                        ArgTy::IaVal => todo!("intrinsic array store"),
+                        _ => unreachable!(),
+                    }
+                    self.registers.write(dest, value);
+                }
                 Instruction::IntrinsicCall { dest: _, start: _, end: _, name: _ } => todo!(),
                 Instruction::OutputCall { start, end, cmd, redir } => {
                     return Ok(Signal::Suspend(self.print_req(start, end, cmd, redir)));
@@ -366,6 +404,19 @@ impl Interpreter<'_> {
         let _ = write!(buf, "{rfs}", rfs = self.symbols.rfs);
 
         IoRequest::WriteStdout(buf)
+    }
+
+    /// Join index register values with `SUBSEP` into an array key (gawk-compatible).
+    fn make_array_key(&self, start: Reg, end: Reg) -> String {
+        let range = self.registers.get_range(start..end);
+        let mut buf = StdVec::new();
+        for (i, value) in range.iter().enumerate() {
+            if i > 0 {
+                self.symbols.subsep.write_string(&mut buf);
+            }
+            value.write_string(&mut buf);
+        }
+        String::from_utf8_lossy(&buf).into_owned()
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,12 +16,14 @@ use crate::cli::{ArgQueueItem, KeyValue};
 
 pub struct AwkRt<'a> {
     intrp: Interpreter<'a>,
-    bc: &'a Bytecode<'a>,
+    // Owned (not `&'a Bytecode<'a>`) so arena-invariant values like
+    // `Rc<RefCell<_>>` arrays do not force a self-borrow of a local.
+    bc: Bytecode<'a>,
     queue: &'a [ArgQueueItem],
 }
 
 impl<'a> AwkRt<'a> {
-    pub fn new(intrp: Interpreter<'a>, bc: &'a Bytecode<'a>, queue: &'a [ArgQueueItem]) -> Self {
+    pub fn new(intrp: Interpreter<'a>, bc: Bytecode<'a>, queue: &'a [ArgQueueItem]) -> Self {
         Self { intrp, bc, queue }
     }
 
@@ -32,14 +34,14 @@ impl<'a> AwkRt<'a> {
 
     /// Runs `code` to completion, dispatching I/O signals from the VM.
     fn drive(&mut self, code: CodeRange) -> Result<CtrlSig> {
-        let mut sig = self.intrp.run_code(self.bc, code.clone())?;
+        let mut sig = self.intrp.run_code(&self.bc, code.clone())?;
         loop {
             let req = match sig {
                 Signal::Suspend(req) => req,
                 Signal::Terminal(t) => return Ok(t),
             };
             let res = self.perform_io(&req);
-            sig = self.intrp.resume(self.bc, code.clone(), req, res)?;
+            sig = self.intrp.resume(&self.bc, code.clone(), req, res)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn uu_main() -> Result<()> {
         writeln!(out, "{table}")?;
     }
 
-    AwkRt::new(intrp, &bc, &args.read_queue).main_event_loop()?;
+    AwkRt::new(intrp, bc, &args.read_queue).main_event_loop()?;
 
     Ok(())
 }

--- a/tests/by-util/test_awk.rs
+++ b/tests/by-util/test_awk.rs
@@ -248,3 +248,68 @@ fn write_to_dev_full_does_not_panic() {
         "awk panicked on write to /dev/full: stderr={stderr}"
     );
 }
+
+#[test]
+fn array_single_index_get_set() {
+    ucmd()
+        .arg("BEGIN { a[1] = 42; print a[1] }")
+        .succeeds()
+        .stdout_only("42\n");
+}
+
+#[test]
+fn array_string_index() {
+    ucmd()
+        .arg(r#"BEGIN { a["foo"] = "bar"; print a["foo"] }"#)
+        .succeeds()
+        .stdout_only("bar\n");
+}
+
+#[test]
+fn array_unset_element_prints_empty() {
+    ucmd()
+        .arg("BEGIN { print a[1]; print \"x\" }")
+        .succeeds()
+        .stdout_only("\nx\n");
+}
+
+#[test]
+fn array_prefix_increment() {
+    ucmd()
+        .arg("BEGIN { ++a[1]; print a[1] }")
+        .succeeds()
+        .stdout_only("1\n");
+}
+
+#[test]
+fn array_add_assign() {
+    ucmd()
+        .arg("BEGIN { a[1] = 10; a[1] += 5; print a[1] }")
+        .succeeds()
+        .stdout_only("15\n");
+}
+
+#[test]
+fn array_multi_index_uses_subsep() {
+    // Multidimensional `a[i,j]` is stored under key i SUBSEP j (default SUBSEP = "\034").
+    ucmd()
+        .arg("BEGIN { a[1, 2] = 9; print a[1, 2] }")
+        .succeeds()
+        .stdout_only("9\n");
+}
+
+#[test]
+fn array_independent_keys() {
+    ucmd()
+        .arg("BEGIN { a[1] = 1; a[2] = 2; print a[1], a[2] }")
+        .succeeds()
+        .stdout_only("1 2\n");
+}
+
+#[test]
+fn array_overwrite_element() {
+    ucmd()
+        .arg("BEGIN { a[1] = 1; a[1] = 2; print a[1] }")
+        .succeeds()
+        .stdout_only("2\n");
+}


### PR DESCRIPTION
Enable single- and multi-index get/set via shared Array storage and SUBSEP-joined keys. Includes lowerer rvalue loads and coverage tests.

Closes: #78